### PR TITLE
feat: Add shell scripting composability

### DIFF
--- a/internal/exitcode/exitcode.go
+++ b/internal/exitcode/exitcode.go
@@ -1,0 +1,43 @@
+// Package exitcode provides standardized exit codes for the CLI.
+// These codes allow shell scripts to programmatically handle different error conditions.
+package exitcode
+
+// Exit codes for the CLI
+const (
+	// Success indicates successful execution
+	Success = 0
+
+	// GeneralError indicates an unknown or general error
+	GeneralError = 1
+
+	// UsageError indicates invalid arguments or flags
+	UsageError = 2
+
+	// ConfigError indicates configuration or credential issues
+	ConfigError = 3
+
+	// AuthError indicates authentication failed (401/403)
+	AuthError = 4
+
+	// APIError indicates an API request failed (4xx)
+	APIError = 5
+
+	// ServerError indicates a server error (5xx)
+	ServerError = 6
+)
+
+// FromHTTPStatus maps HTTP status codes to exit codes
+func FromHTTPStatus(status int) int {
+	switch {
+	case status >= 200 && status < 300:
+		return Success
+	case status == 401 || status == 403:
+		return AuthError
+	case status >= 400 && status < 500:
+		return APIError
+	case status >= 500:
+		return ServerError
+	default:
+		return GeneralError
+	}
+}

--- a/internal/exitcode/exitcode_test.go
+++ b/internal/exitcode/exitcode_test.go
@@ -1,0 +1,61 @@
+package exitcode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		expected int
+	}{
+		// Success codes
+		{"200 OK", 200, Success},
+		{"201 Created", 201, Success},
+		{"204 No Content", 204, Success},
+		{"299 edge case", 299, Success},
+
+		// Auth errors
+		{"401 Unauthorized", 401, AuthError},
+		{"403 Forbidden", 403, AuthError},
+
+		// API errors (other 4xx)
+		{"400 Bad Request", 400, APIError},
+		{"404 Not Found", 404, APIError},
+		{"422 Unprocessable", 422, APIError},
+		{"429 Rate Limited", 429, APIError},
+
+		// Server errors
+		{"500 Internal Server Error", 500, ServerError},
+		{"502 Bad Gateway", 502, ServerError},
+		{"503 Service Unavailable", 503, ServerError},
+		{"504 Gateway Timeout", 504, ServerError},
+
+		// Edge cases
+		{"0 unknown", 0, GeneralError},
+		{"100 informational", 100, GeneralError},
+		{"300 redirect", 300, GeneralError},
+		{"600 still server range", 600, ServerError}, // >= 500 is ServerError
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FromHTTPStatus(tt.status)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExitCodeValues(t *testing.T) {
+	// Verify exit code values match expected standards
+	assert.Equal(t, 0, Success)
+	assert.Equal(t, 1, GeneralError)
+	assert.Equal(t, 2, UsageError)
+	assert.Equal(t, 3, ConfigError)
+	assert.Equal(t, 4, AuthError)
+	assert.Equal(t, 5, APIError)
+	assert.Equal(t, 6, ServerError)
+}


### PR DESCRIPTION
## Summary

Add standardized exit codes for shell scripting composability.

### Exit Codes

| Code | Meaning |
|------|---------|
| 0 | Success |
| 1 | General error |
| 2 | Usage error |
| 3 | Config error (missing API key/account ID) |
| 4 | Auth error (401/403) |
| 5 | API error (4xx) |
| 6 | Server error (5xx) |

### Usage

Shell scripts can now check exit codes for programmatic error handling:

```bash
newrelic-cli apps list || handle_error $?

# Or more specifically:
newrelic-cli apps list
case $? in
  0) echo "Success" ;;
  3) echo "Please configure API key" ;;
  4) echo "Authentication failed" ;;
  *) echo "Command failed" ;;
esac
```

### Changes

- Add `internal/exitcode/` package with exit code constants
- Add `exitcode.FromHTTPStatus()` to map HTTP status codes to exit codes
- Update `main.go` to use typed exit codes based on error type

### Deferred to Follow-up PR

The following features from the original PR were deferred due to codebase restructuring in PR #10:
- `--limit/-l` flag on list commands
- `--force/-f` flag on delete commands

Closes #5

---

🤖 Generated with [Claude Code](https://claude.ai/code)