### PR TITLE
chore: Add GitHub templates and expand .gitignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug Report
+about: Report a bug in newrelic-cli
+title: ''
+labels: bug
+assignees: ''
+---
+
+**newrelic-cli version**
+Run `newrelic-cli --version` and paste the output:
+
+```
+newrelic-cli version ...
+```
+
+**Environment**
+- OS: [e.g., macOS 14.0, Ubuntu 22.04, Windows 11]
+- Shell: [e.g., bash, zsh, PowerShell]
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Run command '...'
+2. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened. Include any error messages.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest a new feature for newrelic-cli
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem?**
+A clear description of the problem. Ex. "I'm always frustrated when..."
+
+**Describe the solution you'd like**
+A clear description of what you want to happen.
+
+**Describe alternatives you've considered**
+Any alternative solutions or features you've considered.
+
+**Example usage**
+Show how you'd use this feature:
+
+```bash
+newrelic-cli <your-proposed-command>
+```
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+Brief description of changes.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] My code follows the project's code style
+- [ ] I have added tests that prove my fix/feature works
+- [ ] All new and existing tests pass (`make test`)
+- [ ] Linting passes (`make lint`)
+- [ ] I have updated documentation if needed
+
+## Related Issues
+
+Closes #(issue number)

--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,48 @@
-# Binaries
-/newrelic-cli
+# Binaries for programs and plugins
 *.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Code coverage profiles and other test artifacts
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# Build outputs
+/newrelic-cli
+bin/
 dist/
 
-# Test coverage
-coverage.out
-coverage.html
+# Debug files
+*.dSYM/
+__debug_bin*
 
-# IDE
-.idea/
-.vscode/
+# Temporary files
+*.tmp
+*.bak
 *.swp
-*.swo
+*~
 
-# OS
+# OS files
 .DS_Store
 Thumbs.db
 
-# Go
+# Editor/IDE
+.idea/
+.vscode/
+
+# Dependency directories
 vendor/


### PR DESCRIPTION
## Summary

- Add PR template with type checkboxes, checklist, and auto-close keywords
- Add bug report issue template with version, environment, and reproduction steps
- Add feature request issue template with problem description and example usage
- Expand .gitignore with comprehensive coverage for Go development

## Test plan

- [ ] Verify PR template appears on new PRs
- [ ] Verify bug report template appears when creating bug issues
- [ ] Verify feature request template appears when creating feature issues
- [ ] Verify .gitignore covers all build artifacts

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)