### PR TITLE
Fix organization references in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ newrelic-cli/
 │   ├── version/version.go      # Build-time version injection via ldflags
 │   └── view/view.go            # Output formatting (table, JSON, plain)
 ├── Makefile                    # Build, test, lint targets
-└── go.mod                      # Module: github.com/piekstra/newrelic-cli
+└── go.mod                      # Module: github.com/open-cli-collective/newrelic-cli
 ```
 
 ## Key Patterns

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ A command-line interface for interacting with New Relic APIs.
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew tap piekstra/tap
-brew install newrelic-cli
+brew tap open-cli-collective/tap
+brew install --cask newrelic-cli
 ```
 
 ### Go Install
 
 ```bash
-go install github.com/piekstra/newrelic-cli/cmd/newrelic-cli@latest
+go install github.com/open-cli-collective/newrelic-cli/cmd/newrelic-cli@latest
 ```
 
 ### Binary Downloads
 
-Download pre-built binaries from the [Releases](https://github.com/piekstra/newrelic-cli/releases) page.
+Download pre-built binaries from the [Releases](https://github.com/open-cli-collective/newrelic-cli/releases) page.
 
 ## Quick Start
 
@@ -820,7 +820,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/piekstra/newrelic-cli/api"
+    "github.com/open-cli-collective/newrelic-cli/api"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Update Homebrew tap from `piekstra/tap` to `open-cli-collective/tap`
- Update `go install` path to use `open-cli-collective` org
- Update Releases page link to point to `open-cli-collective` org
- Update Go library import example in README
- Update CLAUDE.md module path reference

These references were outdated after the repo was moved to the open-cli-collective organization.