### PR TITLE
fix: update goreleaser owner to open-cli-collective

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,5 +48,5 @@ changelog:
 
 release:
   github:
-    owner: piekstra
+    owner: open-cli-collective
     name: newrelic-cli


### PR DESCRIPTION
## Summary

Updates the goreleaser release configuration to publish to `open-cli-collective/newrelic-cli` instead of `piekstra/newrelic-cli`.

This fixes the release workflow failure where uploads were failing with 307 redirects because the releases were being published to the wrong repository.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My code follows the project's code style
- [x] I have updated documentation if needed

## Related Issues
Fixes release workflow failures after repo migration to open-cli-collective org.