### PR TITLE
feat(build): Add Windows amd64 and arm64 builds to GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
@@ -20,8 +21,13 @@ builds:
       - -X github.com/piekstra/newrelic-cli/internal/version.BuildDate={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## Summary

Add Windows platform support to `.goreleaser.yml` to enable distribution via Chocolatey and Winget.

## Changes

- Add `windows` to the `goos` list for cross-compilation
- Add `format_overrides` to use `zip` format for Windows archives (Windows users expect zip, not tar.gz)
- Update to non-deprecated `formats` syntax (list-based) per GoReleaser v2

## Output

After this change, releases will include:
- `newrelic-cli_*_darwin_amd64.tar.gz`
- `newrelic-cli_*_darwin_arm64.tar.gz`
- `newrelic-cli_*_linux_amd64.tar.gz`
- `newrelic-cli_*_linux_arm64.tar.gz`
- `newrelic-cli_*_windows_amd64.zip` (new)
- `newrelic-cli_*_windows_arm64.zip` (new)

## Verification

Ran `make snapshot` locally and confirmed:
- [x] Windows binaries are built (`newrelic-cli.exe`)
- [x] Windows archives use `.zip` format
- [x] `checksums.txt` includes Windows archive hashes
- [x] No deprecation warnings

Closes #35