### PR TITLE
chore: unify Claude Code settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,27 +12,34 @@
       "Bash(rm -rf bin/:*)",
       "Bash(rm -rf dist/:*)",
       "Bash(rm coverage:*)",
-      "Bash(./newrelic-cli:*)",
+      "Bash(./bin/newrelic-cli:*)",
       "WebFetch(domain:go.dev)",
       "WebFetch(domain:pkg.go.dev)",
       "WebFetch(domain:golang.org)",
       "WebFetch(domain:github.com)",
-      "WebFetch(domain:*.github.com)",
+      "WebFetch(domain:goreleaser.com)",
+      "WebFetch(domain:golangci-lint.run)",
       "WebFetch(domain:newrelic.com)",
       "WebFetch(domain:*.newrelic.com)",
       "WebFetch(domain:docs.newrelic.com)",
       "WebFetch(domain:developer.newrelic.com)",
-      "WebFetch(domain:goreleaser.com)",
-      "WebFetch(domain:golangci-lint.run)",
       "WebSearch"
     ],
-    "deny": [
+    "ask": [
       "Bash(git rebase:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)"
+    ],
+    "deny": [
+      "Bash(goreleaser release:*)",
+      "Bash(goreleaser publish:*)",
+      "Bash(goreleaser announce:*)",
+      "Bash(goreleaser continue:*)",
       "Bash(git filter-branch:*)",
       "Bash(git filter-repo:*)",
-      "Bash(goreleaser release:*)",
       "Bash(rm -rf /:*)",
-      "Bash(rm -rf ~:*)"
+      "Bash(rm -rf ~:*)",
+      "Bash(rm -rf .*:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Standardizes Claude Code settings.json for Go development
- Allows common Go development commands (go, make, golangci-lint, goreleaser, git, gh)
- Adds goreleaser release/publish/announce/continue to deny list (CI-only operations)
- Adds git rebase and force push to ask list
- Adds dangerous rm commands to deny list

Closes #42

## Test plan
- [ ] Verify Claude Code respects the new allow list for Go commands
- [ ] Verify denied commands are blocked
- [ ] Verify ask-list commands prompt for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)