### PR TITLE
feat(packaging): Add Winget manifest templates

### DIFF
--- a/packaging/winget/OpenCliCollective.newrelic-cli.installer.yaml
+++ b/packaging/winget/OpenCliCollective.newrelic-cli.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: OpenCliCollective.newrelic-cli
+PackageVersion: 0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: newrelic-cli.exe
+    PortableCommandAlias: newrelic-cli
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/open-cli-collective/newrelic-cli/releases/download/v0.0.0/newrelic-cli_v0.0.0_windows_amd64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+  - Architecture: arm64
+    InstallerUrl: https://github.com/open-cli-collective/newrelic-cli/releases/download/v0.0.0/newrelic-cli_v0.0.0_windows_arm64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/packaging/winget/OpenCliCollective.newrelic-cli.locale.en-US.yaml
+++ b/packaging/winget/OpenCliCollective.newrelic-cli.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: OpenCliCollective.newrelic-cli
+PackageVersion: 0.0.0
+PackageLocale: en-US
+Publisher: open-cli-collective
+PublisherUrl: https://github.com/open-cli-collective
+PackageName: New Relic CLI
+PackageUrl: https://github.com/open-cli-collective/newrelic-cli
+License: MIT
+LicenseUrl: https://github.com/open-cli-collective/newrelic-cli/blob/main/LICENSE
+ShortDescription: Command-line interface for New Relic APIs
+Description: |-
+  A command-line interface for interacting with New Relic APIs.
+
+  Features:
+  - APM Applications: List applications, view details, and retrieve metrics
+  - Alert Policies: List and inspect alert policy configurations
+  - Dashboards: List and view dashboard details
+  - Deployments: Track deployment markers for applications
+  - Entities: Search across all New Relic entity types
+  - Log Parsing Rules: Create, list, update, and delete log parsing rules
+  - NerdGraph: Execute arbitrary GraphQL queries
+  - NRQL: Run NRQL queries directly from the command line
+  - Synthetic Monitors: List and inspect synthetic monitoring configurations
+  - Users: List and view user details
+  - Multiple Output Formats: Table, JSON, and plain (scriptable) output
+Tags:
+  - newrelic
+  - cli
+  - monitoring
+  - apm
+  - observability
+  - devops
+  - sre
+ReleaseNotesUrl: https://github.com/open-cli-collective/newrelic-cli/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/packaging/winget/OpenCliCollective.newrelic-cli.yaml
+++ b/packaging/winget/OpenCliCollective.newrelic-cli.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: OpenCliCollective.newrelic-cli
+PackageVersion: 0.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,97 @@
+# Winget Manifests for newrelic-cli
+
+This directory contains Winget manifest templates for newrelic-cli.
+
+## Manifest Structure
+
+Winget requires three separate manifest files:
+
+```
+winget/
+├── OpenCliCollective.newrelic-cli.yaml              # Version manifest
+├── OpenCliCollective.newrelic-cli.installer.yaml    # Installer manifest
+├── OpenCliCollective.newrelic-cli.locale.en-US.yaml # Locale manifest
+└── README.md                                        # This file
+```
+
+## How It Works
+
+### Placeholder Values
+
+The manifests contain placeholder values that are replaced at release time:
+
+| Placeholder | Purpose | Example Replacement |
+|-------------|---------|---------------------|
+| `0.0.0` | Version | `1.0.14` |
+| 64 zeros | SHA256 checksum | Actual hash from checksums.txt |
+
+### Checksum Replacement
+
+The installer manifest contains two 64-zero placeholders for checksums:
+- First occurrence: x64 checksum
+- Second occurrence: arm64 checksum
+
+**Important**: PowerShell's `-replace` doesn't support a count parameter. Use .NET regex:
+
+```powershell
+$regex = [regex]"0{64}"
+$content = $regex.Replace($content, $env:X64_HASH, 1)   # Replace first match
+$content = $regex.Replace($content, $env:ARM64_HASH, 1) # Replace second match
+```
+
+## Package Identifier
+
+The package identifier follows Winget naming conventions:
+- Format: `Publisher.PackageName`
+- Our identifier: `OpenCliCollective.newrelic-cli`
+
+## Local Validation
+
+To validate the manifests locally (requires Windows with winget installed):
+
+```powershell
+# Create a test directory with processed manifests
+$testDir = "winget-test"
+$testVersion = "0.0.1"
+$testHash1 = "0000000000000000000000000000000000000000000000000000000000000001"
+$testHash2 = "0000000000000000000000000000000000000000000000000000000000000002"
+
+New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+
+# Process version manifest
+$content = Get-Content "OpenCliCollective.newrelic-cli.yaml" -Raw
+$content = $content -replace "0\.0\.0", $testVersion
+Set-Content "$testDir/OpenCliCollective.newrelic-cli.yaml" $content
+
+# Process locale manifest
+$content = Get-Content "OpenCliCollective.newrelic-cli.locale.en-US.yaml" -Raw
+$content = $content -replace "0\.0\.0", $testVersion
+Set-Content "$testDir/OpenCliCollective.newrelic-cli.locale.en-US.yaml" $content
+
+# Process installer manifest
+$content = Get-Content "OpenCliCollective.newrelic-cli.installer.yaml" -Raw
+$content = $content -replace "0\.0\.0", $testVersion
+$regex = [regex]"0{64}"
+$content = $regex.Replace($content, $testHash1, 1)
+$content = $regex.Replace($content, $testHash2, 1)
+Set-Content "$testDir/OpenCliCollective.newrelic-cli.installer.yaml" $content
+
+# Validate
+winget validate --manifest $testDir/
+```
+
+## Submission Process
+
+Unlike Chocolatey (direct push), Winget submissions are **pull requests** to microsoft/winget-pkgs:
+
+1. Release workflow processes templates with actual version and checksums
+2. `wingetcreate submit` creates a PR to microsoft/winget-pkgs
+3. Microsoft's automated validation runs
+4. On success: Auto-merged within minutes
+5. Users can install with: `winget install OpenCliCollective.newrelic-cli`
+
+## References
+
+- [Winget Manifest Schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest)
+- [wingetcreate Tool](https://github.com/microsoft/winget-create)
+- [Winget Package Repository](https://github.com/microsoft/winget-pkgs)


### PR DESCRIPTION
## Summary

Add Winget manifest templates for Windows distribution following the three-file structure required by microsoft/winget-pkgs.

## Changes

Creates `packaging/winget/` with:

| File | Purpose |
|------|---------|
| `OpenCliCollective.newrelic-cli.yaml` | Version manifest |
| `OpenCliCollective.newrelic-cli.installer.yaml` | Installer manifest (x64 + arm64) |
| `OpenCliCollective.newrelic-cli.locale.en-US.yaml` | Locale/metadata manifest |
| `README.md` | Maintainer documentation |

## Manifest Details

### Version Manifest
- Schema: 1.10.0
- PackageIdentifier: `OpenCliCollective.newrelic-cli`

### Installer Manifest
- InstallerType: `zip`
- NestedInstallerType: `portable`
- Architectures: x64 and arm64
- Checksum placeholders: 64 zeros (for build-time injection)

### Locale Manifest
- Full feature description
- Tags: newrelic, cli, monitoring, apm, observability, devops, sre

## Placeholder Values

| Placeholder | Purpose |
|-------------|---------|
| `0.0.0` | Version (replaced at release time) |
| 64 zeros | SHA256 checksums (replaced from checksums.txt) |

## Notes

- URL format matches GoReleaser output: `newrelic-cli_v{version}_windows_{arch}.zip`
- README documents the PowerShell regex gotcha for sequential replacement
- Validation will be done by the test workflow (Issue #39)

Closes #38