### PR TITLE
feat(ci): Add automated Chocolatey publishing to release workflow

### DIFF
--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -1,0 +1,70 @@
+name: Publish to Chocolatey
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.14)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${{ inputs.version }}" --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+
+          # Update version in nuspec
+          $nuspec = 'packaging/chocolatey/newrelic-cli.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
+
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
+
+      - name: Pack and push
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack
+          Get-ChildItem *.nupkg
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,3 +95,57 @@ jobs:
           git add -A
           git commit -m "Update newrelic-cli to ${VERSION_NUM}"
           git push
+
+  chocolatey:
+    needs: goreleaser
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ github.ref_name }}" --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+
+          # Update version in nuspec
+          $nuspec = 'packaging/chocolatey/newrelic-cli.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
+
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack
+          Get-ChildItem *.nupkg
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}


### PR DESCRIPTION
## Summary

Add automated Chocolatey publishing to the release workflow, plus a manual retry workflow.

## Changes

### `.github/workflows/release.yml`
Added `chocolatey` job that:
1. Waits for `goreleaser` job to complete
2. Downloads `checksums.txt` from the release
3. Extracts Windows amd64 and arm64 hashes
4. Updates version in `packaging/chocolatey/newrelic-cli.nuspec`
5. Injects checksums into `packaging/chocolatey/tools/chocolateyInstall.ps1`
6. Runs `choco pack` to create the nupkg
7. Runs `choco push` to publish to Chocolatey

### `.github/workflows/chocolatey-publish.yml` (New)
Manual workflow for retrying failed publishes:
- Takes version input (e.g., `1.0.14`)
- Validates the release exists
- Performs the same checksum injection and publish steps

## Required Secrets

| Secret | How to Obtain |
|--------|---------------|
| `CHOCOLATEY_API_KEY` | https://community.chocolatey.org/account |

## Workflow Diagram

```
Tag Push → GoReleaser → Chocolatey Job
                           ↓
                     Download checksums.txt
                           ↓
                     Extract x64/arm64 hashes
                           ↓
                     Update nuspec version
                           ↓
                     Inject checksums into install script
                           ↓
                     choco pack → choco push
```

## Notes

- Chocolatey job runs on `windows-latest` (Chocolatey CLI pre-installed)
- First submission may take 1-3 days for human moderation review
- Subsequent versions are usually auto-approved within hours once trusted

Closes #37