### PR TITLE
docs: add CI & release workflow documentation to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,16 @@ test(apps): add unit tests for list command
 chore(deps): update cobra to v1.8.0
 ```
 
+| Prefix | Purpose | Triggers Release? |
+|--------|---------|-------------------|
+| `feat:` | New features | Yes |
+| `fix:` | Bug fixes | Yes |
+| `docs:` | Documentation only | No |
+| `test:` | Adding/updating tests | No |
+| `refactor:` | Code changes that don't fix bugs or add features | No |
+| `chore:` | Maintenance tasks | No |
+| `ci:` | CI/CD changes | No |
+
 ### Pull Request Process
 
 1. Create feature branch from `main`
@@ -252,6 +262,21 @@ chore(deps): update cobra to v1.8.0
 3. Run `make verify`
 4. Push and create PR targeting `main`
 5. Add reviewer
+
+## CI & Release Workflow
+
+Releases are automated with a dual-gate system to avoid unnecessary releases:
+
+**Gate 1 - Path filter:** Only triggers when Go code changes (`**.go`, `go.mod`, `go.sum`)
+**Gate 2 - Commit prefix:** Only `feat:` and `fix:` commits create releases
+
+This means:
+- `feat: add command` + Go files changed → release
+- `fix: handle edge case` + Go files changed → release
+- `docs:`, `ci:`, `test:`, `refactor:` → no release
+- Changes only to docs, packaging, workflows → no release
+
+**After merging a release-triggering PR:** The workflow creates a tag, which triggers GoReleaser to build binaries and publish to Homebrew. Chocolatey and Winget require manual workflow dispatch.
 
 ## Common Tasks
 


### PR DESCRIPTION
## Summary
- Add table showing which commit prefixes trigger releases
- Add CI & Release Workflow section explaining the dual-gate system

Closes #49