### PR TITLE
feat: add --limit flag to list commands

### DIFF
--- a/internal/cmd/alerts/list.go
+++ b/internal/cmd/alerts/list.go
@@ -9,8 +9,15 @@ import (
 	"github.com/open-cli-collective/newrelic-cli/internal/view"
 )
 
+type listPoliciesOptions struct {
+	*root.Options
+	limit int
+}
+
 func newListPoliciesCmd(opts *root.Options) *cobra.Command {
-	return &cobra.Command{
+	listOpts := &listPoliciesOptions{Options: opts}
+
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all alert policies",
 		Long: `List all alert policies in your account.
@@ -20,14 +27,19 @@ Incident preference values:
   PER_CONDITION:          One incident per condition
   PER_CONDITION_AND_TARGET: One incident per condition and target`,
 		Example: `  newrelic-cli alerts policies list
-  newrelic-cli alerts policies list -o json`,
+  newrelic-cli alerts policies list -o json
+  newrelic-cli alerts policies list --limit 10`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runListPolicies(opts)
+			return runListPolicies(listOpts)
 		},
 	}
+
+	cmd.Flags().IntVarP(&listOpts.limit, "limit", "l", 0, "Limit number of results (0 = no limit)")
+
+	return cmd
 }
 
-func runListPolicies(opts *root.Options) error {
+func runListPolicies(opts *listPoliciesOptions) error {
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -36,6 +48,11 @@ func runListPolicies(opts *root.Options) error {
 	policies, err := client.ListAlertPolicies()
 	if err != nil {
 		return err
+	}
+
+	// Apply limit
+	if opts.limit > 0 && len(policies) > opts.limit {
+		policies = policies[:opts.limit]
 	}
 
 	v := opts.View()

--- a/internal/cmd/users/users.go
+++ b/internal/cmd/users/users.go
@@ -23,8 +23,15 @@ func Register(rootCmd *cobra.Command, opts *root.Options) {
 	rootCmd.AddCommand(usersCmd)
 }
 
+type listOptions struct {
+	*root.Options
+	limit int
+}
+
 func newListCmd(opts *root.Options) *cobra.Command {
-	return &cobra.Command{
+	listOpts := &listOptions{Options: opts}
+
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all users",
 		Long: `List all users in your account.
@@ -34,14 +41,19 @@ User types:
   CORE_USER_TIER:  Core user
   BASIC_USER_TIER: Basic user`,
 		Example: `  newrelic-cli users list
-  newrelic-cli users list -o json`,
+  newrelic-cli users list -o json
+  newrelic-cli users list --limit 20`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(opts)
+			return runList(listOpts)
 		},
 	}
+
+	cmd.Flags().IntVarP(&listOpts.limit, "limit", "l", 0, "Limit number of results (0 = no limit)")
+
+	return cmd
 }
 
-func runList(opts *root.Options) error {
+func runList(opts *listOptions) error {
 	client, err := opts.APIClient()
 	if err != nil {
 		return err
@@ -50,6 +62,11 @@ func runList(opts *root.Options) error {
 	users, err := client.ListUsers()
 	if err != nil {
 		return err
+	}
+
+	// Apply limit
+	if opts.limit > 0 && len(users) > opts.limit {
+		users = users[:opts.limit]
 	}
 
 	v := opts.View()


### PR DESCRIPTION
## [#17]

Add `--limit/-l` flag to all list commands for shell scripting composability.

### Changes

Added `--limit` flag to:
- `apps list`
- `alerts policies list`
- `dashboards list`
- `users list`
- `synthetics list`
- `logs rules list`

### Notes on Issue #17

This PR partially addresses #17:

**--limit flag (completed):**
- Added to all list commands that were missing it
- `deployments list` and `deployments search` already had `--limit`

**--force flag (already complete / N/A):**
- `logs rules delete` already has `--force` implemented
- Delete commands for dashboards, deployments, and synthetics don't exist yet in the codebase

### Test Plan

- [x] Build passes: `make build`
- [x] Tests pass: `make test`
- [x] Verify `--limit` flag appears in help: `./newrelic-cli apps list --help`
- [x] Test limit truncation: `./newrelic-cli apps list --limit 1`