### PR TITLE
docs: update command examples to use nrq binary name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,11 +6,11 @@ labels: bug
 assignees: ''
 ---
 
-**newrelic-cli version**
-Run `newrelic-cli --version` and paste the output:
+**nrq version**
+Run `nrq --version` and paste the output:
 
 ```
-newrelic-cli version ...
+nrq version ...
 ```
 
 **Environment**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,7 +19,7 @@ Any alternative solutions or features you've considered.
 Show how you'd use this feature:
 
 ```bash
-newrelic-cli <your-proposed-command>
+nrq <your-proposed-command>
 ```
 
 **Additional context**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ make install
 ### Verify Installation
 
 ```bash
-./newrelic-cli --version
+./nrq --version
 ```
 
 ## Code Style
@@ -155,7 +155,7 @@ git push -u origin your-branch
 
 ```
 newrelic-cli/
-├── cmd/newrelic-cli/          # Entry point
+├── cmd/nrq/                   # Entry point
 │   └── main.go
 ├── api/                        # Public Go library
 │   ├── client.go              # HTTP client, New(), NewWithConfig()
@@ -259,7 +259,7 @@ func runList(opts *root.Options) error {
 
 ### Step 4: Register in main.go
 
-`cmd/newrelic-cli/main.go`:
+`cmd/nrq/main.go`:
 
 ```go
 import (

--- a/api/errors.go
+++ b/api/errors.go
@@ -7,8 +7,8 @@ import (
 
 // Common errors
 var (
-	ErrAccountIDRequired = errors.New("account ID required - run 'newrelic-cli config set-account-id' or set NEWRELIC_ACCOUNT_ID")
-	ErrAPIKeyRequired    = errors.New("API key required - run 'newrelic-cli config set-api-key' or set NEWRELIC_API_KEY")
+	ErrAccountIDRequired = errors.New("account ID required - run 'nrq config set-account-id' or set NEWRELIC_ACCOUNT_ID")
+	ErrAPIKeyRequired    = errors.New("API key required - run 'nrq config set-api-key' or set NEWRELIC_API_KEY")
 	ErrNotFound          = errors.New("resource not found")
 	ErrUnauthorized      = errors.New("unauthorized: invalid or missing API key")
 )

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,6 +1,6 @@
 # Integration Test Checklist
 
-This document provides a manual testing checklist for verifying newrelic-cli functionality against a live New Relic account.
+This document provides a manual testing checklist for verifying nrq functionality against a live New Relic account.
 
 ## Prerequisites
 
@@ -25,11 +25,11 @@ This makes it easy to identify and clean up test data after testing.
 
 ```bash
 # Configure credentials
-newrelic-cli config set-api-key
-newrelic-cli config set-account-id <your-account-id>
+nrq config set-api-key
+nrq config set-account-id <your-account-id>
 
 # Verify configuration
-newrelic-cli config show
+nrq config show
 ```
 
 ---
@@ -40,13 +40,13 @@ newrelic-cli config show
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| List apps (table) | `newrelic-cli apps list` | Table with ID, NAME, LANGUAGE, STATUS columns | [ ] |
-| List apps (JSON) | `newrelic-cli apps list -o json` | Valid JSON array | [ ] |
-| List apps (plain) | `newrelic-cli apps list -o plain` | Tab-separated, no headers | [ ] |
-| Get app | `newrelic-cli apps get <id>` | App details displayed | [ ] |
-| Get app (JSON) | `newrelic-cli apps get <id> -o json` | Valid JSON object | [ ] |
-| Get invalid app | `newrelic-cli apps get 99999999` | Error message, exit code 1 | [ ] |
-| List metrics | `newrelic-cli apps metrics <id>` | List of metric names | [ ] |
+| List apps (table) | `nrq apps list` | Table with ID, NAME, LANGUAGE, STATUS columns | [ ] |
+| List apps (JSON) | `nrq apps list -o json` | Valid JSON array | [ ] |
+| List apps (plain) | `nrq apps list -o plain` | Tab-separated, no headers | [ ] |
+| Get app | `nrq apps get <id>` | App details displayed | [ ] |
+| Get app (JSON) | `nrq apps get <id> -o json` | Valid JSON object | [ ] |
+| Get invalid app | `nrq apps get 99999999` | Error message, exit code 1 | [ ] |
+| List metrics | `nrq apps metrics <id>` | List of metric names | [ ] |
 
 **Notes:**
 - Record an app ID for use in later tests: `__________`
@@ -57,10 +57,10 @@ newrelic-cli config show
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| List policies (table) | `newrelic-cli alerts policies list` | Table with ID, NAME, INCIDENT PREFERENCE | [ ] |
-| List policies (JSON) | `newrelic-cli alerts policies list -o json` | Valid JSON array | [ ] |
-| Get policy | `newrelic-cli alerts policies get <id>` | Policy details displayed | [ ] |
-| Get invalid policy | `newrelic-cli alerts policies get 99999999` | Error message | [ ] |
+| List policies (table) | `nrq alerts policies list` | Table with ID, NAME, INCIDENT PREFERENCE | [ ] |
+| List policies (JSON) | `nrq alerts policies list -o json` | Valid JSON array | [ ] |
+| Get policy | `nrq alerts policies get <id>` | Policy details displayed | [ ] |
+| Get invalid policy | `nrq alerts policies get 99999999` | Error message | [ ] |
 
 **Notes:**
 - Record a policy ID for reference: `__________`
@@ -71,10 +71,10 @@ newrelic-cli config show
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| List dashboards (table) | `newrelic-cli dashboards list` | Table with GUID, NAME, PAGES | [ ] |
-| List dashboards (JSON) | `newrelic-cli dashboards list -o json` | Valid JSON array | [ ] |
-| Get dashboard | `newrelic-cli dashboards get <guid>` | Dashboard details displayed | [ ] |
-| Get dashboard (JSON) | `newrelic-cli dashboards get <guid> -o json` | Valid JSON with pages/widgets | [ ] |
+| List dashboards (table) | `nrq dashboards list` | Table with GUID, NAME, PAGES | [ ] |
+| List dashboards (JSON) | `nrq dashboards list -o json` | Valid JSON array | [ ] |
+| Get dashboard | `nrq dashboards get <guid>` | Dashboard details displayed | [ ] |
+| Get dashboard (JSON) | `nrq dashboards get <guid> -o json` | Valid JSON with pages/widgets | [ ] |
 
 **Notes:**
 - Record a dashboard GUID for reference: `__________`
@@ -85,11 +85,11 @@ newrelic-cli config show
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| List deployments | `newrelic-cli deployments list <app-id>` | Table or "No deployments found" | [ ] |
-| Create deployment | `newrelic-cli deployments create <app-id> -r "newrelic-cli-test-v1.0.0" -d "Test deployment"` | Success message with ID | [ ] |
-| Create deployment (JSON) | `newrelic-cli deployments create <app-id> -r "newrelic-cli-test-v1.0.1" -o json` | Valid JSON object | [ ] |
-| Verify created | `newrelic-cli deployments list <app-id>` | Shows test deployments | [ ] |
-| Missing revision | `newrelic-cli deployments create <app-id>` | Error about required flag | [ ] |
+| List deployments | `nrq deployments list <app-id>` | Table or "No deployments found" | [ ] |
+| Create deployment | `nrq deployments create <app-id> -r "newrelic-cli-test-v1.0.0" -d "Test deployment"` | Success message with ID | [ ] |
+| Create deployment (JSON) | `nrq deployments create <app-id> -r "newrelic-cli-test-v1.0.1" -o json` | Valid JSON object | [ ] |
+| Verify created | `nrq deployments list <app-id>` | Shows test deployments | [ ] |
+| Missing revision | `nrq deployments create <app-id>` | Error about required flag | [ ] |
 
 **Notes:**
 - Test deployments will appear in New Relic UI for the application
@@ -100,10 +100,10 @@ newrelic-cli config show
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| Search by type | `newrelic-cli entities search "type = 'APPLICATION'"` | Table with APM apps | [ ] |
-| Search by name | `newrelic-cli entities search "name LIKE '%'"` | Table with entities | [ ] |
-| Search (JSON) | `newrelic-cli entities search "type = 'APPLICATION'" -o json` | Valid JSON array | [ ] |
-| Empty results | `newrelic-cli entities search "name = 'nonexistent-entity-xyz'"` | "No entities found" | [ ] |
+| Search by type | `nrq entities search "type = 'APPLICATION'"` | Table with APM apps | [ ] |
+| Search by name | `nrq entities search "name LIKE '%'"` | Table with entities | [ ] |
+| Search (JSON) | `nrq entities search "type = 'APPLICATION'" -o json` | Valid JSON array | [ ] |
+| Empty results | `nrq entities search "name = 'nonexistent-entity-xyz'"` | "No entities found" | [ ] |
 
 ---
 
@@ -111,20 +111,20 @@ newrelic-cli config show
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| List rules | `newrelic-cli logs rules list` | Table or "No log parsing rules found" | [ ] |
-| List rules (JSON) | `newrelic-cli logs rules list -o json` | Valid JSON array | [ ] |
+| List rules | `nrq logs rules list` | Table or "No log parsing rules found" | [ ] |
+| List rules (JSON) | `nrq logs rules list -o json` | Valid JSON array | [ ] |
 | Create rule | See command below | Success message with ID | [ ] |
-| Verify created | `newrelic-cli logs rules list` | Shows test rule | [ ] |
-| Update rule description | `newrelic-cli logs rules update <rule-id> --description "newrelic-cli-test-updated"` | Success message | [ ] |
-| Update rule (disable) | `newrelic-cli logs rules update <rule-id> --disabled` | Success message | [ ] |
-| Update rule (JSON) | `newrelic-cli logs rules update <rule-id> --description "test" -o json` | Valid JSON object | [ ] |
-| Verify update persisted | `newrelic-cli logs rules list` | Shows updated description | [ ] |
-| Delete rule | `newrelic-cli logs rules delete <rule-id>` | Success message | [ ] |
-| Verify deleted | `newrelic-cli logs rules list` | Test rule removed | [ ] |
+| Verify created | `nrq logs rules list` | Shows test rule | [ ] |
+| Update rule description | `nrq logs rules update <rule-id> --description "newrelic-cli-test-updated"` | Success message | [ ] |
+| Update rule (disable) | `nrq logs rules update <rule-id> --disabled` | Success message | [ ] |
+| Update rule (JSON) | `nrq logs rules update <rule-id> --description "test" -o json` | Valid JSON object | [ ] |
+| Verify update persisted | `nrq logs rules list` | Shows updated description | [ ] |
+| Delete rule | `nrq logs rules delete <rule-id>` | Success message | [ ] |
+| Verify deleted | `nrq logs rules list` | Test rule removed | [ ] |
 
 **Create rule command:**
 ```bash
-newrelic-cli logs rules create \
+nrq logs rules create \
   --description "newrelic-cli-test-rule" \
   --grok "Test %{WORD:test_field}" \
   --nrql "SELECT * FROM Log WHERE message LIKE 'Test%'" \
@@ -141,9 +141,9 @@ newrelic-cli logs rules create \
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| Simple query | `newrelic-cli nerdgraph query '{ actor { user { email } } }'` | JSON with user email | [ ] |
-| Account query | `newrelic-cli nerdgraph query '{ actor { accounts { id name } } }'` | JSON with accounts | [ ] |
-| Invalid query | `newrelic-cli nerdgraph query '{ invalid }'` | Error message | [ ] |
+| Simple query | `nrq nerdgraph query '{ actor { user { email } } }'` | JSON with user email | [ ] |
+| Account query | `nrq nerdgraph query '{ actor { accounts { id name } } }'` | JSON with accounts | [ ] |
+| Invalid query | `nrq nerdgraph query '{ invalid }'` | Error message | [ ] |
 
 ---
 
@@ -151,10 +151,10 @@ newrelic-cli logs rules create \
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| Count query | `newrelic-cli nrql query "SELECT count(*) FROM Transaction SINCE 1 hour ago"` | JSON with count | [ ] |
-| Facet query | `newrelic-cli nrql query "SELECT count(*) FROM Transaction FACET appName SINCE 1 hour ago"` | JSON with facets | [ ] |
-| Invalid NRQL | `newrelic-cli nrql query "SELECT * FROM InvalidEventType"` | Error or empty results | [ ] |
-| Empty results | `newrelic-cli nrql query "SELECT count(*) FROM Transaction WHERE 1=0"` | JSON with count = 0 | [ ] |
+| Count query | `nrq nrql query "SELECT count(*) FROM Transaction SINCE 1 hour ago"` | JSON with count | [ ] |
+| Facet query | `nrq nrql query "SELECT count(*) FROM Transaction FACET appName SINCE 1 hour ago"` | JSON with facets | [ ] |
+| Invalid NRQL | `nrq nrql query "SELECT * FROM InvalidEventType"` | Error or empty results | [ ] |
+| Empty results | `nrq nrql query "SELECT count(*) FROM Transaction WHERE 1=0"` | JSON with count = 0 | [ ] |
 
 ---
 
@@ -162,10 +162,10 @@ newrelic-cli logs rules create \
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| List monitors | `newrelic-cli synthetics list` | Table or "No synthetic monitors found" | [ ] |
-| List monitors (JSON) | `newrelic-cli synthetics list -o json` | Valid JSON array | [ ] |
-| Get monitor | `newrelic-cli synthetics get <id>` | Monitor details | [ ] |
-| Get invalid monitor | `newrelic-cli synthetics get invalid-id` | Error message | [ ] |
+| List monitors | `nrq synthetics list` | Table or "No synthetic monitors found" | [ ] |
+| List monitors (JSON) | `nrq synthetics list -o json` | Valid JSON array | [ ] |
+| Get monitor | `nrq synthetics get <id>` | Monitor details | [ ] |
+| Get invalid monitor | `nrq synthetics get invalid-id` | Error message | [ ] |
 
 **Notes:**
 - Requires at least one synthetic monitor in the account
@@ -176,10 +176,10 @@ newrelic-cli logs rules create \
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| List users | `newrelic-cli users list` | Table with ID, NAME, EMAIL, ROLE | [ ] |
-| List users (JSON) | `newrelic-cli users list -o json` | Valid JSON array | [ ] |
-| Get user | `newrelic-cli users get <id>` | User details | [ ] |
-| Get invalid user | `newrelic-cli users get 99999999` | Error message | [ ] |
+| List users | `nrq users list` | Table with ID, NAME, EMAIL, ROLE | [ ] |
+| List users (JSON) | `nrq users list -o json` | Valid JSON array | [ ] |
+| Get user | `nrq users get <id>` | User details | [ ] |
+| Get invalid user | `nrq users get 99999999` | Error message | [ ] |
 
 ---
 
@@ -187,11 +187,11 @@ newrelic-cli logs rules create \
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| Show config | `newrelic-cli config show` | Status with masked key, account ID, region | [ ] |
-| Set region US | `newrelic-cli config set-region US` | Success message | [ ] |
-| Set region EU | `newrelic-cli config set-region EU` | Success message | [ ] |
-| Invalid region | `newrelic-cli config set-region XX` | Error message | [ ] |
-| Set account ID | `newrelic-cli config set-account-id 12345` | Success message | [ ] |
+| Show config | `nrq config show` | Status with masked key, account ID, region | [ ] |
+| Set region US | `nrq config set-region US` | Success message | [ ] |
+| Set region EU | `nrq config set-region EU` | Success message | [ ] |
+| Invalid region | `nrq config set-region XX` | Error message | [ ] |
+| Set account ID | `nrq config set-account-id 12345` | Success message | [ ] |
 
 ---
 
@@ -235,9 +235,9 @@ For each command that supports output formats, verify:
 
 | Test | Command | Expected | Pass |
 |------|---------|----------|------|
-| `--no-color` | `newrelic-cli apps list --no-color` | No ANSI color codes | [ ] |
-| `--help` | `newrelic-cli apps --help` | Help text displayed | [ ] |
-| `--version` | `newrelic-cli --version` | Version info with commit, date | [ ] |
+| `--no-color` | `nrq apps list --no-color` | No ANSI color codes | [ ] |
+| `--help` | `nrq apps --help` | Help text displayed | [ ] |
+| `--version` | `nrq --version` | Version info with commit, date | [ ] |
 
 ---
 

--- a/internal/cmd/alerts/get.go
+++ b/internal/cmd/alerts/get.go
@@ -13,8 +13,8 @@ func newGetPolicyCmd(opts *root.Options) *cobra.Command {
 		Use:   "get <policy-id>",
 		Short: "Get details for a specific alert policy",
 		Long:  `Get detailed information about a specific alert policy including its incident preference setting.`,
-		Example: `  newrelic-cli alerts policies get 12345
-  newrelic-cli alerts policies get 12345 -o json`,
+		Example: `  nrq alerts policies get 12345
+  nrq alerts policies get 12345 -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGetPolicy(opts, args[0])

--- a/internal/cmd/alerts/list.go
+++ b/internal/cmd/alerts/list.go
@@ -26,9 +26,9 @@ Incident preference values:
   PER_POLICY:             One incident per policy
   PER_CONDITION:          One incident per condition
   PER_CONDITION_AND_TARGET: One incident per condition and target`,
-		Example: `  newrelic-cli alerts policies list
-  newrelic-cli alerts policies list -o json
-  newrelic-cli alerts policies list --limit 10`,
+		Example: `  nrq alerts policies list
+  nrq alerts policies list -o json
+  nrq alerts policies list --limit 10`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runListPolicies(listOpts)
 		},

--- a/internal/cmd/apps/get.go
+++ b/internal/cmd/apps/get.go
@@ -15,8 +15,8 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Long: `Get detailed information about a specific APM application.
 
 Displays ID, name, language, health status, reporting status, and last reported time.`,
-		Example: `  newrelic-cli apps get 12345678
-  newrelic-cli apps get 12345678 -o json`,
+		Example: `  nrq apps get 12345678
+  nrq apps get 12345678 -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(opts, args[0])

--- a/internal/cmd/apps/list.go
+++ b/internal/cmd/apps/list.go
@@ -25,16 +25,16 @@ func newListCmd(opts *root.Options) *cobra.Command {
 Displays application ID, name, language, and health status.
 Health status values: green (healthy), orange (warning), red (critical), gray (not reporting).`,
 		Example: `  # List all applications
-  newrelic-cli apps list
+  nrq apps list
 
   # Output as JSON for scripting
-  newrelic-cli apps list -o json
+  nrq apps list -o json
 
   # Plain output for parsing
-  newrelic-cli apps list -o plain | cut -f1  # Get app IDs only
+  nrq apps list -o plain | cut -f1  # Get app IDs only
 
   # Limit results
-  newrelic-cli apps list --limit 5`,
+  nrq apps list --limit 5`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(listOpts)
 		},

--- a/internal/cmd/apps/metrics.go
+++ b/internal/cmd/apps/metrics.go
@@ -17,8 +17,8 @@ func newMetricsCmd(opts *root.Options) *cobra.Command {
 Metric names follow the format: Category/Name (e.g., Apdex, HttpDispatcher,
 WebTransaction/Function/handler). Use these names with the Metric API or
 in NRQL queries with FROM Metric.`,
-		Example: `  newrelic-cli apps metrics 12345678
-  newrelic-cli apps metrics 12345678 -o json`,
+		Example: `  nrq apps metrics 12345678
+  nrq apps metrics 12345678 -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runMetrics(opts, args[0])

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -18,34 +18,34 @@ func Register(rootCmd *cobra.Command, opts *root.Options) {
 To load completions:
 
 Bash:
-  $ source <(newrelic-cli completion bash)
+  $ source <(nrq completion bash)
 
   # To load completions for each session, execute once:
   # Linux:
-  $ newrelic-cli completion bash > /etc/bash_completion.d/newrelic-cli
+  $ nrq completion bash > /etc/bash_completion.d/newrelic-cli
 
   # macOS:
-  $ newrelic-cli completion bash > $(brew --prefix)/etc/bash_completion.d/newrelic-cli
+  $ nrq completion bash > $(brew --prefix)/etc/bash_completion.d/newrelic-cli
 
 Zsh:
-  $ source <(newrelic-cli completion zsh)
+  $ source <(nrq completion zsh)
 
   # To load completions for each session, execute once:
-  $ newrelic-cli completion zsh > "${fpath[1]}/_newrelic-cli"
+  $ nrq completion zsh > "${fpath[1]}/_newrelic-cli"
 
   # You may need to start a new shell for completions to take effect.
 
 Fish:
-  $ newrelic-cli completion fish | source
+  $ nrq completion fish | source
 
   # To load completions for each session, execute once:
-  $ newrelic-cli completion fish > ~/.config/fish/completions/newrelic-cli.fish
+  $ nrq completion fish > ~/.config/fish/completions/newrelic-cli.fish
 
 PowerShell:
-  PS> newrelic-cli completion powershell | Out-String | Invoke-Expression
+  PS> nrq completion powershell | Out-String | Invoke-Expression
 
   # To load completions for each session, add to your profile:
-  PS> newrelic-cli completion powershell >> $PROFILE`,
+  PS> nrq completion powershell >> $PROFILE`,
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),

--- a/internal/cmd/configcmd/config.go
+++ b/internal/cmd/configcmd/config.go
@@ -18,7 +18,7 @@ import (
 func Register(rootCmd *cobra.Command, opts *root.Options) {
 	configCmd := &cobra.Command{
 		Use:   "config",
-		Short: "Configure newrelic-cli credentials",
+		Short: "Configure nrq credentials",
 	}
 
 	configCmd.AddCommand(newSetAPIKeyCmd(opts))
@@ -280,7 +280,7 @@ func runShow(opts *root.Options) error {
 	// Check for permission warnings (Linux only)
 	if warning := config.CheckPermissions(); warning != "" {
 		v.Warning(warning)
-		v.Println("Run 'newrelic-cli config fix-permissions' to correct this")
+		v.Println("Run 'nrq config fix-permissions' to correct this")
 		v.Println("")
 	}
 
@@ -408,7 +408,7 @@ Verifies:
   - API key is valid
   - Account is accessible (if account ID is configured)
   - NerdGraph API is responding`,
-		Example: `  newrelic-cli config test`,
+		Example: `  nrq config test`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runTest(opts)
 		},
@@ -481,8 +481,8 @@ func runTest(opts *root.Options) error {
 			v.Println("Error: " + result.ErrorMessage)
 		}
 		v.Println("")
-		v.Println("Check your credentials with: newrelic-cli config show")
-		v.Println("Reconfigure with: newrelic-cli init")
+		v.Println("Check your credentials with: nrq config show")
+		v.Println("Reconfigure with: nrq init")
 		return fmt.Errorf("API key validation failed")
 	}
 
@@ -526,12 +526,12 @@ func newClearCmd(opts *root.Options) *cobra.Command {
 		Long: `Remove all stored credentials (API key, account ID, and region).
 
 This is a convenience command equivalent to running:
-  newrelic-cli config delete-api-key
-  newrelic-cli config delete-account-id
+  nrq config delete-api-key
+  nrq config delete-account-id
 
 Note: Environment variables (NEWRELIC_*) will still be used if set.`,
-		Example: `  newrelic-cli config clear
-  newrelic-cli config clear --force`,
+		Example: `  nrq config clear
+  nrq config clear --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runClear(clearOpts)
 		},

--- a/internal/cmd/dashboards/dashboards.go
+++ b/internal/cmd/dashboards/dashboards.go
@@ -45,9 +45,9 @@ func newListCmd(opts *root.Options) *cobra.Command {
 
 Displays dashboard GUID, name, and account ID. The GUID is a base64-encoded
 entity identifier that can be used with 'dashboards get'.`,
-		Example: `  newrelic-cli dashboards list
-  newrelic-cli dashboards list -o json
-  newrelic-cli dashboards list --limit 10`,
+		Example: `  nrq dashboards list
+  nrq dashboards list -o json
+  nrq dashboards list --limit 10`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(listOpts)
 		},
@@ -102,8 +102,8 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 
 The GUID is a base64-encoded entity identifier from 'dashboards list' or
 the New Relic UI (visible in the dashboard URL).`,
-		Example: `  newrelic-cli dashboards get "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg="
-  newrelic-cli dashboards get "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg=" -o json`,
+		Example: `  nrq dashboards get "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg="
+  nrq dashboards get "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg=" -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(opts, api.EntityGUID(args[0]))
@@ -183,10 +183,10 @@ The JSON file should contain the dashboard definition with the following structu
 
 Permissions: PUBLIC_READ_WRITE, PUBLIC_READ_ONLY, PRIVATE`,
 		Example: `  # Create a dashboard from a JSON file
-  newrelic-cli dashboards create --from-file dashboard.json
+  nrq dashboards create --from-file dashboard.json
 
   # Create and output result as JSON
-  newrelic-cli dashboards create --from-file dashboard.json -o json`,
+  nrq dashboards create --from-file dashboard.json -o json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreate(createOpts)
 		},
@@ -262,10 +262,10 @@ func newUpdateCmd(opts *root.Options) *cobra.Command {
 The JSON file format is the same as for 'dashboards create'.
 The GUID identifies which dashboard to update.`,
 		Example: `  # Update a dashboard from a JSON file
-  newrelic-cli dashboards update "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg=" --from-file dashboard.json
+  nrq dashboards update "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg=" --from-file dashboard.json
 
   # Update and output result as JSON
-  newrelic-cli dashboards update "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg=" --from-file dashboard.json -o json`,
+  nrq dashboards update "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg=" --from-file dashboard.json -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(updateOpts, api.EntityGUID(args[0]))
@@ -344,10 +344,10 @@ Use --force to skip the confirmation prompt.
 
 WARNING: This action cannot be undone.`,
 		Example: `  # Delete with confirmation
-  newrelic-cli dashboards delete "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg="
+  nrq dashboards delete "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg="
 
   # Delete without confirmation (use with caution)
-  newrelic-cli dashboards delete "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg=" --force`,
+  nrq dashboards delete "MjcxMjY0MHxWSVp8REFTSEJPQVJEXDI5Mjg=" --force`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDelete(deleteOpts, api.EntityGUID(args[0]))

--- a/internal/cmd/deployments/deployments.go
+++ b/internal/cmd/deployments/deployments.go
@@ -50,20 +50,20 @@ The application can be specified by:
 
 Examples:
   # By app ID
-  newrelic-cli deployments list 12345678
+  nrq deployments list 12345678
 
   # By application name
-  newrelic-cli deployments list --name "my-production-app"
+  nrq deployments list --name "my-production-app"
 
   # By entity GUID
-  newrelic-cli deployments list --guid "MjcxMjY0MHxBUE18QVBQTElDQVRJT058MTM3NzA4OTc5OQ"
+  nrq deployments list --guid "MjcxMjY0MHxBUE18QVBQTElDQVRJT058MTM3NzA4OTc5OQ"
 
   # With time filtering
-  newrelic-cli deployments list 12345678 --since "7 days ago"
-  newrelic-cli deployments list --name "my-app" --since "2025-01-01" --until "2025-01-15"
+  nrq deployments list 12345678 --since "7 days ago"
+  nrq deployments list --name "my-app" --since "2025-01-01" --until "2025-01-15"
 
   # Limit results
-  newrelic-cli deployments list --name "my-app" --limit 5`,
+  nrq deployments list --name "my-app" --limit 5`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(listOpts, args)
@@ -176,8 +176,8 @@ The application can be specified by:
   - Entity GUID (--guid flag)
 
 Examples:
-  newrelic-cli deployments create 12345678 --revision "v1.2.3"
-  newrelic-cli deployments create --name "my-app" --revision "v1.2.3" --description "Bug fixes"`,
+  nrq deployments create 12345678 --revision "v1.2.3"
+  nrq deployments create --name "my-app" --revision "v1.2.3" --description "Bug fixes"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreate(createOpts, args)
@@ -263,16 +263,16 @@ across all applications in your account.
 
 Examples:
   # Find deployments for apps matching a pattern
-  newrelic-cli deployments search "entity.name LIKE '%insights%'"
+  nrq deployments search "entity.name LIKE '%insights%'"
 
   # Find deployments by a specific user
-  newrelic-cli deployments search "user = 'deploy-bot'"
+  nrq deployments search "user = 'deploy-bot'"
 
   # Search with time bounds
-  newrelic-cli deployments search "entity.name LIKE '%prod%'" --since "7 days ago"
+  nrq deployments search "entity.name LIKE '%prod%'" --since "7 days ago"
 
   # Limit results
-  newrelic-cli deployments search "revision LIKE 'v2%'" --limit 10`,
+  nrq deployments search "revision LIKE 'v2%'" --limit 10`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSearch(searchOpts, args[0])

--- a/internal/cmd/entities/entities.go
+++ b/internal/cmd/entities/entities.go
@@ -42,19 +42,19 @@ Common domains and types:
   SYNTH:    MONITOR
   VIZ:      DASHBOARD`,
 		Example: `  # Find all APM applications
-  newrelic-cli entities search "type = 'APPLICATION'"
+  nrq entities search "type = 'APPLICATION'"
 
   # Find by name pattern
-  newrelic-cli entities search "name LIKE 'production%'"
+  nrq entities search "name LIKE 'production%'"
 
   # Find by domain
-  newrelic-cli entities search "domain = 'APM'"
+  nrq entities search "domain = 'APM'"
 
   # Combined conditions
-  newrelic-cli entities search "domain = 'APM' AND name LIKE 'api%'"
+  nrq entities search "domain = 'APM' AND name LIKE 'api%'"
 
   # Find dashboards
-  newrelic-cli entities search "type = 'DASHBOARD'"`,
+  nrq entities search "type = 'DASHBOARD'"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSearch(opts, args[0])

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -36,13 +36,13 @@ This interactive wizard will guide you through setting up:
 
 After configuration, the connection is tested automatically.`,
 		Example: `  # Interactive setup
-  newrelic-cli init
+  nrq init
 
   # Non-interactive setup
-  newrelic-cli init --api-key NRAK-xxx --account-id 12345 --region US
+  nrq init --api-key NRAK-xxx --account-id 12345 --region US
 
   # Skip connection verification
-  newrelic-cli init --no-verify`,
+  nrq init --no-verify`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInit(initOpts)
 		},
@@ -157,7 +157,7 @@ func runInit(opts *initOptions) error {
 			v.Error("Failed to create client: %v", err)
 			v.Println("")
 			v.Println("Configuration saved but connection test failed.")
-			v.Println("You can test again with: newrelic-cli config test")
+			v.Println("You can test again with: nrq config test")
 			return nil
 		}
 
@@ -194,8 +194,8 @@ func runInit(opts *initOptions) error {
 	v.Success("Configuration saved.")
 	v.Println("")
 	v.Println("Try it out:")
-	v.Println("  newrelic-cli apps list")
-	v.Println("  newrelic-cli nrql \"SELECT count(*) FROM Transaction\"")
+	v.Println("  nrq apps list")
+	v.Println("  nrq nrql \"SELECT count(*) FROM Transaction\"")
 
 	return nil
 }

--- a/internal/cmd/logs/logs.go
+++ b/internal/cmd/logs/logs.go
@@ -48,9 +48,9 @@ func newListRulesCmd(opts *root.Options) *cobra.Command {
 
 Displays rule ID, description, enabled status, and last update time.
 Use 'logs rules create' to add new rules or 'logs rules delete' to remove them.`,
-		Example: `  newrelic-cli logs rules list
-  newrelic-cli logs rules list -o json
-  newrelic-cli logs rules list --limit 10`,
+		Example: `  nrq logs rules list
+  nrq logs rules list -o json
+  nrq logs rules list --limit 10`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runListRules(listOpts)
 		},
@@ -173,32 +173,32 @@ IMPORTANT:
   - Existing logs will NOT be retroactively parsed
   - If parsed returns null in NRQL tests, your pattern doesn't match`,
 		Example: `  # Parse user login events
-  newrelic-cli logs rules create \
+  nrq logs rules create \
     --description "Parse user login events" \
     --grok "User %{UUID:user_id} logged in from %{IP:ip_address}" \
     --nrql "SELECT * FROM Log WHERE message LIKE 'User % logged in%'"
 
   # Parse HTTP access logs
-  newrelic-cli logs rules create \
+  nrq logs rules create \
     --description "Parse HTTP access logs" \
     --grok "%{IP:client} - - %{DATA:timestamp} \"%{WORD:method} %{DATA:path}\" %{NUMBER:status}" \
     --nrql "SELECT * FROM Log WHERE logtype = 'accesslog'"
 
   # Parse error logs with Lucene filter
-  newrelic-cli logs rules create \
+  nrq logs rules create \
     --description "Parse application errors" \
     --grok "ERROR %{TIMESTAMP_ISO8601:ts} %{DATA:class}: %{GREEDYDATA:message}" \
     --nrql "SELECT * FROM Log WHERE level = 'error'" \
     --lucene "message:ERROR"
 
   # Handle optional prefix (logs from multiple sources)
-  newrelic-cli logs rules create \
+  nrq logs rules create \
     --description "Parse with optional prefix" \
     --grok "(?:^|%{GREEDYDATA}\s)%{DATA:service}::%{UUID:id} - %{GREEDYDATA:msg}" \
     --nrql "SELECT * FROM Log WHERE message LIKE '%::%'"
 
   # Custom regex capture for non-standard formats
-  newrelic-cli logs rules create \
+  nrq logs rules create \
     --description "Parse custom ID format" \
     --grok "%{GREEDYDATA}(?<custom_id>[A-Z]{3}-[0-9]{4})" \
     --nrql "SELECT * FROM Log WHERE message LIKE '%-%'"`,
@@ -315,26 +315,26 @@ IMPORTANT:
   - Existing logs will NOT be retroactively parsed
   - If parsed returns null in NRQL tests, your pattern doesn't match`,
 		Example: `  # Update the description
-  newrelic-cli logs rules update rule-123 --description "Updated description"
+  nrq logs rules update rule-123 --description "Updated description"
 
   # Update the GROK pattern
-  newrelic-cli logs rules update rule-123 --grok "%{IP:client} %{WORD:method}"
+  nrq logs rules update rule-123 --grok "%{IP:client} %{WORD:method}"
 
   # Disable a rule
-  newrelic-cli logs rules update rule-123 --disabled
+  nrq logs rules update rule-123 --disabled
 
   # Update multiple fields
-  newrelic-cli logs rules update rule-123 \
+  nrq logs rules update rule-123 \
     --description "Parse HTTP logs" \
     --grok "%{COMBINEDAPACHELOG}" \
     --enabled
 
   # Update to handle optional prefix
-  newrelic-cli logs rules update rule-123 \
+  nrq logs rules update rule-123 \
     --grok "(?:^|%{GREEDYDATA}\s)%{DATA:service}::%{UUID:id} - %{GREEDYDATA:msg}"
 
   # Update with custom regex capture
-  newrelic-cli logs rules update rule-123 \
+  nrq logs rules update rule-123 \
     --grok "%{GREEDYDATA}(?<custom_id>[A-Z]{3}-[0-9]{4})"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/nerdgraph/nerdgraph.go
+++ b/internal/cmd/nerdgraph/nerdgraph.go
@@ -32,13 +32,13 @@ available queries and mutations:
 
 Output is always JSON format.`,
 		Example: `  # Get current user info
-  newrelic-cli nerdgraph query '{ actor { user { email name } } }'
+  nrq nerdgraph query '{ actor { user { email name } } }'
 
   # List accounts
-  newrelic-cli nerdgraph query '{ actor { accounts { id name } } }'
+  nrq nerdgraph query '{ actor { accounts { id name } } }'
 
   # Get entity by GUID
-  newrelic-cli nerdgraph query '{
+  nrq nerdgraph query '{
     actor {
       entity(guid: "YOUR_ENTITY_GUID") {
         name
@@ -49,7 +49,7 @@ Output is always JSON format.`,
   }'
 
   # Run NRQL query via GraphQL
-  newrelic-cli nerdgraph query '{
+  nrq nerdgraph query '{
     actor {
       account(id: 12345678) {
         nrql(query: "SELECT count(*) FROM Transaction SINCE 1 hour ago") {
@@ -60,7 +60,7 @@ Output is always JSON format.`,
   }'
 
   # Search entities
-  newrelic-cli nerdgraph query '{
+  nrq nerdgraph query '{
     actor {
       entitySearch(query: "domain = '\''APM'\'' AND type = '\''APPLICATION'\''") {
         results {

--- a/internal/cmd/nrql/nrql.go
+++ b/internal/cmd/nrql/nrql.go
@@ -35,20 +35,20 @@ Supported time formats:
   - Special: "now", "today", "yesterday"
   - Absolute: "2025-01-01", "2025-01-01T00:00:00Z"`,
 		Example: `  # Direct query (shortcut)
-  newrelic-cli nrql "SELECT count(*) FROM Transaction SINCE 1 hour ago"
+  nrq nrql "SELECT count(*) FROM Transaction SINCE 1 hour ago"
 
   # Using query subcommand
-  newrelic-cli nrql query "SELECT count(*) FROM Transaction"
+  nrq nrql query "SELECT count(*) FROM Transaction"
 
   # Using --since flag (appends to query)
-  newrelic-cli nrql "SELECT count(*) FROM Transaction" --since "7 days ago"
+  nrq nrql "SELECT count(*) FROM Transaction" --since "7 days ago"
 
   # Using both --since and --until
-  newrelic-cli nrql "SELECT * FROM Log" --since "2025-01-01" --until "2025-01-15"`,
+  nrq nrql "SELECT * FROM Log" --since "2025-01-01" --until "2025-01-15"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return fmt.Errorf("query is required\n\nUsage:\n  newrelic-cli nrql \"<query>\"\n  newrelic-cli nrql query \"<query>\"\n\nDid you mean: newrelic-cli nrql query \"<your-query>\"?")
+				return fmt.Errorf("query is required\n\nUsage:\n  nrq nrql \"<query>\"\n  nrq nrql query \"<query>\"\n\nDid you mean: nrq nrql query \"<your-query>\"?")
 			}
 			return runQuery(queryOpts, args[0])
 		},
@@ -71,9 +71,9 @@ func newQueryCmd(opts *queryOptions) *cobra.Command {
 
 Time ranges can be specified either in the query itself (SINCE/UNTIL clauses)
 or via --since and --until flags which will be appended to your query.`,
-		Example: `  newrelic-cli nrql query "SELECT count(*) FROM Transaction SINCE 1 hour ago"
-  newrelic-cli nrql query "SELECT * FROM Log LIMIT 10"
-  newrelic-cli nrql query "SELECT count(*) FROM Transaction" --since "7 days ago"`,
+		Example: `  nrq nrql query "SELECT count(*) FROM Transaction SINCE 1 hour ago"
+  nrq nrql query "SELECT * FROM Log LIMIT 10"
+  nrq nrql query "SELECT count(*) FROM Transaction" --since "7 days ago"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runQuery(opts, args[0])

--- a/internal/cmd/synthetics/synthetics.go
+++ b/internal/cmd/synthetics/synthetics.go
@@ -50,9 +50,9 @@ Monitor types:
   SCRIPT_BROWSER: Scripted browser with custom scripts
 
 Status values: ENABLED, DISABLED, MUTED`,
-		Example: `  newrelic-cli synthetics list
-  newrelic-cli synthetics list -o json
-  newrelic-cli synthetics list --limit 10`,
+		Example: `  nrq synthetics list
+  nrq synthetics list -o json
+  nrq synthetics list --limit 10`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(listOpts)
 		},
@@ -107,8 +107,8 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Short: "Get details for a specific synthetic monitor",
 		Long: `Get detailed information about a synthetic monitor including
 its type, status, frequency, and target URI (for applicable types).`,
-		Example: `  newrelic-cli synthetics get abc-123-def-456
-  newrelic-cli synthetics get abc-123-def-456 -o json`,
+		Example: `  nrq synthetics get abc-123-def-456
+  nrq synthetics get abc-123-def-456 -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(opts, args[0])
@@ -184,10 +184,10 @@ Status values: ENABLED, DISABLED, MUTED
 Common locations: AWS_US_EAST_1, AWS_US_EAST_2, AWS_US_WEST_1, AWS_US_WEST_2,
                   AWS_EU_WEST_1, AWS_EU_WEST_2, AWS_EU_CENTRAL_1, AWS_AP_SOUTHEAST_1`,
 		Example: `  # Create a monitor from a JSON file
-  newrelic-cli synthetics create --from-file monitor.json
+  nrq synthetics create --from-file monitor.json
 
   # Create and output result as JSON
-  newrelic-cli synthetics create --from-file monitor.json -o json`,
+  nrq synthetics create --from-file monitor.json -o json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCreate(createOpts)
 		},
@@ -270,10 +270,10 @@ func newUpdateCmd(opts *root.Options) *cobra.Command {
 The JSON file format is similar to 'synthetics create', but the type cannot be changed.
 The monitor-id identifies which monitor to update.`,
 		Example: `  # Update a monitor from a JSON file
-  newrelic-cli synthetics update abc-123-def-456 --from-file monitor.json
+  nrq synthetics update abc-123-def-456 --from-file monitor.json
 
   # Update and output result as JSON
-  newrelic-cli synthetics update abc-123-def-456 --from-file monitor.json -o json`,
+  nrq synthetics update abc-123-def-456 --from-file monitor.json -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(updateOpts, args[0])
@@ -352,10 +352,10 @@ Use --force to skip the confirmation prompt.
 
 WARNING: This action cannot be undone.`,
 		Example: `  # Delete with confirmation
-  newrelic-cli synthetics delete abc-123-def-456
+  nrq synthetics delete abc-123-def-456
 
   # Delete without confirmation (use with caution)
-  newrelic-cli synthetics delete abc-123-def-456 --force`,
+  nrq synthetics delete abc-123-def-456 --force`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDelete(deleteOpts, args[0])

--- a/internal/cmd/users/users.go
+++ b/internal/cmd/users/users.go
@@ -40,9 +40,9 @@ User types:
   FULL_USER_TIER:  Full platform user
   CORE_USER_TIER:  Core user
   BASIC_USER_TIER: Basic user`,
-		Example: `  newrelic-cli users list
-  newrelic-cli users list -o json
-  newrelic-cli users list --limit 20`,
+		Example: `  nrq users list
+  nrq users list -o json
+  nrq users list --limit 20`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(listOpts)
 		},
@@ -97,8 +97,8 @@ func newGetCmd(opts *root.Options) *cobra.Command {
 		Short: "Get details for a specific user",
 		Long: `Get detailed information about a user including their authentication
 domain and group memberships.`,
-		Example: `  newrelic-cli users get 12345
-  newrelic-cli users get 12345 -o json`,
+		Example: `  nrq users get 12345
+  nrq users get 12345 -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(opts, args[0])

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ func GetAPIKey() (string, error) {
 		return key, nil
 	}
 
-	return "", fmt.Errorf("no API key found - run 'newrelic-cli config set-api-key' or set NEWRELIC_API_KEY")
+	return "", fmt.Errorf("no API key found - run 'nrq config set-api-key' or set NEWRELIC_API_KEY")
 }
 
 // SetAPIKey stores the New Relic API key
@@ -61,7 +61,7 @@ func GetAccountID() (string, error) {
 		return id, nil
 	}
 
-	return "", fmt.Errorf("no account ID found - run 'newrelic-cli config set-account-id' or set NEWRELIC_ACCOUNT_ID")
+	return "", fmt.Errorf("no account ID found - run 'nrq config set-account-id' or set NEWRELIC_ACCOUNT_ID")
 }
 
 // SetAccountID stores the New Relic account ID

--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -15,7 +15,7 @@ if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
     $arch = 'amd64'
     $checksum = $checksumAmd64
 } else {
-    throw "32-bit Windows is not supported. newrelic-cli requires 64-bit Windows."
+    throw "32-bit Windows is not supported. nrq requires 64-bit Windows."
 }
 
 $baseUrl = "https://github.com/open-cli-collective/newrelic-cli/releases/download/v${version}"
@@ -36,4 +36,4 @@ Install-ChocolateyZipPackage -PackageName $env:ChocolateyPackageName `
 New-Item "$toolsDir\LICENSE.ignore" -Type File -Force | Out-Null
 New-Item "$toolsDir\README.md.ignore" -Type File -Force | Out-Null
 
-Write-Host "newrelic-cli installed successfully. Run 'nrq --help' to get started."
+Write-Host "nrq installed successfully. Run 'nrq --help' to get started."

--- a/packaging/chocolatey/tools/chocolateyUninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyUninstall.ps1
@@ -8,4 +8,4 @@ Remove-Item "$toolsDir\README.md" -Force -ErrorAction SilentlyContinue
 Remove-Item "$toolsDir\LICENSE.ignore" -Force -ErrorAction SilentlyContinue
 Remove-Item "$toolsDir\README.md.ignore" -Force -ErrorAction SilentlyContinue
 
-Write-Host "newrelic-cli has been uninstalled."
+Write-Host "nrq has been uninstalled."


### PR DESCRIPTION
## Summary

Update documentation to use the new short binary name `nrq` instead of `newrelic-cli` in all command examples.

### Files updated:
- `api/errors.go` - error messages with command hints
- `internal/config/config.go` - error messages with command hints
- All `internal/cmd/*/` Example fields (~20 files)
- `.github/ISSUE_TEMPLATE/*` - version check commands
- `docs/integration-tests.md` - all command examples
- `CONTRIBUTING.md` - verify/example commands, directory structure
- `packaging/chocolatey/tools/*.ps1` - user messages

### What stays unchanged:
- Config directory paths (`~/.config/newrelic-cli/`) - for backward compatibility
- Keychain service name (`newrelic-cli`) - for credential migration
- Go module paths
- GitHub URLs
- Package names (Chocolatey/Winget identifier is still `newrelic-cli`)

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] Grep for remaining `newrelic-cli ` command patterns (verified none remain)

🤖 Generated with [Claude Code](https://claude.ai/code)