### PR TITLE
feat: add Linux distribution support (Snap, APT, RPM)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,3 +243,41 @@ jobs:
 
           Write-Host "`nSubmitting new package to Winget..."
           ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir
+
+  snap:
+    if: false  # Temporarily disabled - waiting for personal-files interface approval
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Publish to Snapcraft Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable
+
+  linux-packages:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger linux-packages repo update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LINUX_PACKAGES_DISPATCH_TOKEN }}
+          repository: open-cli-collective/linux-packages
+          event-type: package-release
+          client-payload: |-
+            {
+              "package": "nrq",
+              "version": "${{ github.ref_name }}",
+              "repo": "open-cli-collective/newrelic-cli"
+            }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,26 @@ archives:
       - goos: windows
         formats:
           - zip
+    files:
+      - LICENSE
+      - README.md
+
+# Linux packages (.deb and .rpm)
+nfpms:
+  - id: nrq
+    package_name: nrq
+    vendor: Open CLI Collective
+    homepage: https://github.com/open-cli-collective/newrelic-cli
+    maintainer: Open CLI Collective <https://github.com/open-cli-collective>
+    description: Command-line interface for New Relic
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/licenses/nrq/LICENSE
 
 checksum:
   name_template: checksums.txt

--- a/README.md
+++ b/README.md
@@ -19,22 +19,90 @@ A command-line interface for interacting with New Relic APIs.
 
 ## Installation
 
-### Homebrew (macOS/Linux)
+### macOS
+
+**Homebrew (recommended)**
 
 ```bash
-brew tap open-cli-collective/tap
-brew install --cask newrelic-cli
+brew install open-cli-collective/tap/newrelic-cli
 ```
 
-### Go Install
+> Note: This installs from our third-party tap.
+
+---
+
+### Windows
+
+**Chocolatey**
+
+```powershell
+choco install newrelic-cli
+```
+
+**Winget**
+
+```powershell
+winget install OpenCLICollective.newrelic-cli
+```
+
+---
+
+### Linux
+
+**Snap**
+
+```bash
+sudo snap install ocli-newrelic
+```
+
+> Note: After installation, the command is available as `nrq`.
+
+**APT (Debian/Ubuntu)**
+
+```bash
+# Add the GPG key
+curl -fsSL https://open-cli-collective.github.io/linux-packages/keys/gpg.asc | sudo gpg --dearmor -o /usr/share/keyrings/open-cli-collective.gpg
+
+# Add the repository
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/open-cli-collective.gpg] https://open-cli-collective.github.io/linux-packages/apt stable main" | sudo tee /etc/apt/sources.list.d/open-cli-collective.list
+
+# Install
+sudo apt update
+sudo apt install nrq
+```
+
+> Note: This is our third-party APT repository, not official Debian/Ubuntu repos.
+
+**DNF/YUM (Fedora/RHEL/CentOS)**
+
+```bash
+# Add the repository
+sudo tee /etc/yum.repos.d/open-cli-collective.repo << 'EOF'
+[open-cli-collective]
+name=Open CLI Collective
+baseurl=https://open-cli-collective.github.io/linux-packages/rpm
+enabled=1
+gpgcheck=1
+gpgkey=https://open-cli-collective.github.io/linux-packages/keys/gpg.asc
+EOF
+
+# Install
+sudo dnf install nrq
+```
+
+> Note: This is our third-party RPM repository, not official Fedora/RHEL repos.
+
+**Binary download**
+
+Download `.deb`, `.rpm`, or `.tar.gz` from the [Releases](https://github.com/open-cli-collective/newrelic-cli/releases) page.
+
+---
+
+### From Source
 
 ```bash
 go install github.com/open-cli-collective/newrelic-cli/cmd/nrq@latest
 ```
-
-### Binary Downloads
-
-Download pre-built binaries from the [Releases](https://github.com/open-cli-collective/newrelic-cli/releases) page.
 
 ## Quick Start
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,62 @@
+name: ocli-newrelic
+base: core22
+version: git
+summary: Command-line interface for New Relic
+description: |
+  nrq is a CLI for interacting with New Relic APIs.
+
+  Features:
+  - APM applications, alert policies, and dashboards
+  - Deployment markers and entity search
+  - NRQL queries and NerdGraph GraphQL
+  - Synthetic monitors and log parsing rules
+  - Secure credential storage
+
+  Run 'nrq config set-api-key' to configure your API key.
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+plugs:
+  dot-config-newrelic-cli:
+    interface: personal-files
+    read:
+      - $HOME/.config/newrelic-cli
+    write:
+      - $HOME/.config/newrelic-cli
+
+apps:
+  ocli-newrelic:
+    command: bin/nrq
+    plugs:
+      - home
+      - network
+      - dot-config-newrelic-cli
+    aliases:
+      - nrq
+
+parts:
+  nrq:
+    plugin: go
+    source: .
+    build-snaps:
+      - go/1.24/stable
+    build-environment:
+      - CGO_ENABLED: "0"
+    override-build: |
+      # Get version from git
+      VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+      COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+      DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+      # Build with ldflags
+      go build -o $SNAPCRAFT_PART_INSTALL/bin/nrq \
+        -ldflags "-s -w \
+          -X github.com/open-cli-collective/newrelic-cli/internal/version.Version=${VERSION} \
+          -X github.com/open-cli-collective/newrelic-cli/internal/version.Commit=${COMMIT} \
+          -X github.com/open-cli-collective/newrelic-cli/internal/version.BuildDate=${DATE}" \
+        ./cmd/nrq


### PR DESCRIPTION
## Summary

Add Linux distribution support for newrelic-cli, enabling users to install via:
- **Snap Store** (as `ocli-newrelic`, aliased to `nrq`)
- **APT** (Debian/Ubuntu) via open-cli-collective linux-packages repo
- **DNF/YUM** (Fedora/RHEL/CentOS) via open-cli-collective linux-packages repo
- **Direct download** of `.deb` and `.rpm` packages from GitHub Releases

## Changes

- **`.goreleaser.yml`**: Added `nfpms` section to generate `.deb` and `.rpm` packages
- **`snap/snapcraft.yaml`**: New file for Snap package definition with:
  - `personal-files` interface for `~/.config/newrelic-cli` access
  - Go 1.24 build with version ldflags
- **`.github/workflows/release.yml`**: Added two new jobs:
  - `snap`: Build and publish to Snap Store (disabled with `if: false` pending personal-files interface approval)
  - `linux-packages`: Trigger APT/RPM repo update via repository dispatch
- **`README.md`**: Comprehensive Linux installation instructions

## Required Secrets (to be added before release)

| Secret | Purpose |
|--------|---------|
| `SNAPCRAFT_STORE_CREDENTIALS` | Publish to Snap Store |
| `LINUX_PACKAGES_DISPATCH_TOKEN` | Trigger linux-packages workflow |

## Notes

- Snap job is disabled (`if: false`) pending personal-files interface approval from Canonical
- Uses `ocli-newrelic` as snap name with `nrq` alias

## Test Plan

- [x] `goreleaser check` passes
- [x] `make build` succeeds
- [x] `make test` passes
- [x] `make lint` passes
- [ ] After merge: Verify `.deb`/`.rpm` packages appear in GitHub Release
- [ ] After secrets configured: Verify linux-packages dispatch triggers

Closes #66