### PR TITLE
Rename Chocolatey package from newrelic-cli to nrq-cli

### DIFF
--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -49,7 +49,7 @@ jobs:
           $version = "${{ inputs.version }}"
 
           # Update version in nuspec
-          $nuspec = 'packaging/chocolatey/newrelic-cli.nuspec'
+          $nuspec = 'packaging/chocolatey/nrq-cli.nuspec'
           (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
           Write-Host "Updated nuspec to version $version"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
           $version = "${{ github.ref_name }}".TrimStart('v')
 
           # Update version in nuspec
-          $nuspec = 'packaging/chocolatey/newrelic-cli.nuspec'
+          $nuspec = 'packaging/chocolatey/nrq-cli.nuspec'
           (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
           Write-Host "Updated nuspec to version $version"
 

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -30,9 +30,9 @@ jobs:
         working-directory: packaging/chocolatey
         run: |
           # Replace placeholder version with test version (must not be prerelease)
-          (Get-Content newrelic-cli.nuspec) `
+          (Get-Content nrq-cli.nuspec) `
             -replace '<version>0.0.0</version>', '<version>0.0.1</version>' |
-            Set-Content newrelic-cli.nuspec
+            Set-Content nrq-cli.nuspec
 
           # Create a simple install script that uses the local binary
           # (the real script downloads from GitHub, but we test structure here)
@@ -56,7 +56,7 @@ jobs:
       - name: Install package locally
         shell: pwsh
         working-directory: packaging/chocolatey
-        run: choco install newrelic-cli -dv -s . --force
+        run: choco install nrq-cli -dv -s . --force
 
       - name: Verify installation
         shell: pwsh
@@ -72,7 +72,7 @@ jobs:
       - name: Test uninstall
         shell: pwsh
         run: |
-          choco uninstall newrelic-cli -y
+          choco uninstall nrq-cli -y
 
           # Verify nrq is no longer available
           $nrqPath = Get-Command nrq -ErrorAction SilentlyContinue

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ brew install open-cli-collective/tap/newrelic-cli
 **Chocolatey**
 
 ```powershell
-choco install newrelic-cli
+choco install nrq-cli
 ```
 
 **Winget**

--- a/packaging/chocolatey/nrq-cli.nuspec
+++ b/packaging/chocolatey/nrq-cli.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>newrelic-cli</id>
+    <id>nrq-cli</id>
     <version>0.0.0</version>
-    <title>New Relic CLI</title>
+    <title>nrq - New Relic CLI</title>
     <authors>open-cli-collective</authors>
     <owners>open-cli-collective</owners>
     <licenseUrl>https://github.com/open-cli-collective/newrelic-cli/blob/main/LICENSE</licenseUrl>


### PR DESCRIPTION
## Summary

The Chocolatey package name `newrelic-cli` conflicts with an existing package from another party. This PR renames the package to `nrq-cli` to avoid the collision.

## Changes

- Rename `packaging/chocolatey/newrelic-cli.nuspec` → `nrq-cli.nuspec`
- Update package ID to `nrq-cli`
- Update all workflow references (release, chocolatey-publish, test-chocolatey)
- Update README installation instructions

## Installation after merge

```powershell
choco install nrq-cli
```

## What stays the same

- Binary name (`nrq.exe`)
- Download URLs
- Install/uninstall script logic
- All other packaging (Homebrew, Winget, Snap, APT, DNF)

Closes #68