### PR TITLE
Enable snap job in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,6 @@ jobs:
           ./wingetcreate.exe submit --token ${{ secrets.WINGET_GITHUB_TOKEN }} $manifestDir
 
   snap:
-    if: false  # Temporarily disabled - waiting for personal-files interface approval
     needs: goreleaser
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removes the `if: false` condition from the snap job so it will run on the next release.

The snap will be built and uploaded to the Snapcraft store. Personal-files interface approval is still pending, but having the snap in the store is required to request the interface.

Closes #70