### PR TITLE
feat(ci): enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-    # Gate 1: Only trigger when Go code actually changes
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
 
 permissions:
   contents: write
@@ -16,7 +11,7 @@ permissions:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    # Gate 2: Only release for feat: and fix: commits (actual functionality changes)
+    # Only release for feat: and fix: commits (actual functionality changes)
     if: >-
       startsWith(github.event.head_commit.message, 'feat:') ||
       startsWith(github.event.head_commit.message, 'feat(') ||

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check conventional commit prefix
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          PATTERN="^(feat|fix|docs|refactor|test|chore|ci|perf|build|style|revert)(\(.+\))?!?: .+"
+
+          if [[ ! "$TITLE" =~ $PATTERN ]]; then
+            echo "::error::PR title must use conventional commit format: type(scope): description"
+            echo ""
+            echo "Valid prefixes: feat, fix, docs, refactor, test, chore, ci, perf, build, style, revert"
+            echo ""
+            echo "Examples:"
+            echo "  feat(nrql): add --link flag for deep links"
+            echo "  fix(api): handle empty response body"
+            echo "  docs: update README with new commands"
+            echo ""
+            echo "Why: Squash merges use the PR title as the commit message."
+            echo "Auto-release triggers on feat: and fix: prefixes."
+            echo "See CONTRIBUTING.md for details."
+            exit 1
+          fi
+
+          echo "PR title is valid: $TITLE"


### PR DESCRIPTION
## Summary

- Add PR title lint CI check that validates conventional commit format (`feat:`, `fix:`, `docs:`, etc.)
- Remove `paths:` filter from auto-release workflow — the `feat:`/`fix:` prefix check is sufficient gating

The `paths:` filter caused PRs #84 and #85 to not trigger auto-release because the squash commit messages didn't have `feat:` prefixes. With the new PR title lint, all PRs are forced to use conventional commit format, making the path filter redundant.

## Test plan

- [ ] PR title lint fails for titles like `Add new feature`
- [ ] PR title lint passes for titles like `feat: add new feature`
- [ ] Merging this PR triggers auto-release (title starts with `feat:`)