### PR TITLE
feat: improve DashboardWidget doc comment for layout field

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -255,7 +255,7 @@ type DashboardPage struct {
 	Widgets []DashboardWidget `json:"widgets"`
 }
 
-// DashboardWidget represents a widget on a dashboard page
+// DashboardWidget represents a widget on a dashboard page, including its layout position
 type DashboardWidget struct {
 	ID            string                 `json:"id"`
 	Title         string                 `json:"title"`


### PR DESCRIPTION
Trivial doc comment update to trigger auto-release for layout support added in #87.

The merge commit for #87 didn't use conventional commit format, and the empty commit in #88 didn't touch `.go` files, so the release workflow path filter didn't match.