### PR TITLE
feat: installer-driven init flags + minimal `nrq me` [INT-444]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ newrelic-cli/
 │   │   ├── deployments/        # deployments list, create
 │   │   ├── entities/           # entities search
 │   │   ├── logs/               # logs rules list, create, delete
+│   │   ├── me/                 # me — identity/access check (verifies the key)
 │   │   ├── nerdgraph/          # nerdgraph query
 │   │   ├── nrql/               # nrql query
 │   │   ├── synthetics/         # synthetics list, get
@@ -320,6 +321,14 @@ optional `keyring.backend: file` opt-in.
 - **Ingress only** (`init` / `set-credential`): stdin, `--*-from-env <VAR>`,
   or an interactive no-echo prompt — never a flag/positional literal (§1.5).
   `nrq config set-api-key` is removed (hard error → migration message).
+- **Installer / non-interactive:** `nrq init --non-interactive` (init-only)
+  fails loud instead of prompting for any missing value, incl. the
+  file-backend passphrase (policy threaded via `keychain.OpenForInit`).
+  `--account-id-from-env <VAR>` is the non-secret twin of
+  `--api-key-from-env` — same `op→env→--*-from-env` channel, but resolves
+  into `config.yml`, never the keyring (§2.5). `nrq me` is the scripted
+  verify (`opts.APIClient()` → `TestConnection`; non-zero on bad key /
+  inaccessible configured account; never prints the key).
 - **Runtime resolution:** API key from the keyring only (the single lazy
   chokepoint is `root.Options.APIClient`, which also runs the one-time §1.8
   migration). `account_id`/`region`: env > config.yml.
@@ -337,7 +346,7 @@ optional `keyring.backend: file` opt-in.
 | Variable | Description |
 |----------|-------------|
 | `NEWRELIC_API_KEY` | User API key (NRAK-xxx) — **setup ingress only** (`init`/`set-credential` `--from-env`); not read at runtime |
-| `NEWRELIC_ACCOUNT_ID` | Account ID (non-secret runtime override; env > config.yml) |
+| `NEWRELIC_ACCOUNT_ID` | Account ID — non-secret runtime override (env > config.yml); also the installer ingress target for `nrq init --account-id-from-env NEWRELIC_ACCOUNT_ID` (resolved into `config.yml`, never the keyring) |
 | `NEWRELIC_REGION` | US or EU (non-secret runtime override; env > config.yml) |
 | `NEWRELIC_CLI_KEYRING_BACKEND` | `file` to force the encrypted-file backend (§1.4) |
 | `NEWRELIC_CLI_KEYRING_PASSPHRASE` | File-backend passphrase for headless use (§1.4) |

--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ nrq apps list
 nrq init
 op read "op://Vault/New Relic/api key" | nrq init --api-key-stdin --account-id 12345 --region US
 
+# Fully non-interactive (central installer: op resolves refs into env vars)
+nrq init --region US \
+  --api-key-from-env NEWRELIC_API_KEY \
+  --account-id-from-env NEWRELIC_ACCOUNT_ID \
+  --non-interactive
+
+# Verify the resolved credential / account (exits non-zero if broken)
+nrq me
+nrq me -o json
+
 # Low-level scripted secret ingress (single key, stdin or env — never a flag value)
 nrq set-credential --key api_key --stdin
 nrq set-credential --key api_key --from-env NEWRELIC_API_KEY
@@ -163,6 +173,15 @@ nrq config clear --all    # also removes config.yml
 > disk or accepted as a positional/flag value (§1.5). Use `nrq init` or
 > `nrq set-credential`. `config set-account-id` / `config set-region` are
 > deprecated thin aliases of `config set` (one cycle).
+
+> **Installer / non-interactive `init`:** `--api-key-from-env <VAR>` ingests
+> the secret into the keyring; `--account-id-from-env <VAR>` ingests the
+> **non-secret** account ID into `config.yml` (same `op→env→--*-from-env`
+> channel, never the keyring). `--non-interactive` makes `init` fail loudly
+> instead of prompting for any missing value — including the file-backend
+> passphrase. `nrq me` resolves the credential and prints the authenticated
+> user/account, exiting non-zero if the key is invalid or the configured
+> account is inaccessible (scripted health check / installer `verify`).
 
 ### Credential Storage
 

--- a/cmd/nrq/main.go
+++ b/cmd/nrq/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/initcmd"
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/keys"
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/logs"
+	"github.com/open-cli-collective/newrelic-cli/internal/cmd/me"
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/nerdgraph"
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/nrql"
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/root"
@@ -37,6 +38,7 @@ func main() {
 		initcmd.Register,
 		keys.Register,
 		logs.Register,
+		me.Register,
 		nerdgraph.Register,
 		nrql.Register,
 		synthetics.Register,

--- a/internal/cmd/initcmd/init.go
+++ b/internal/cmd/initcmd/init.go
@@ -27,12 +27,14 @@ import (
 
 type initOptions struct {
 	*root.Options
-	apiKeyEnv   string // --api-key-from-env NAME
-	apiKeyStdin bool   // --api-key-stdin
-	accountID   string // non-secret
-	region      string // non-secret
-	overwrite   bool   // resolve a §1.8 legacy/keyring conflict
-	noVerify    bool
+	apiKeyEnv      string // --api-key-from-env NAME
+	apiKeyStdin    bool   // --api-key-stdin
+	accountID      string // --account-id (non-secret literal)
+	accountIDEnv   string // --account-id-from-env NAME (non-secret env-bridge)
+	region         string // non-secret
+	overwrite      bool   // resolve a §1.8 legacy/keyring conflict
+	nonInteractive bool   // fail loud instead of prompting (installer; §1.3)
+	noVerify       bool
 }
 
 func (o *initOptions) secretFromFlags() bool { return o.apiKeyStdin || o.apiKeyEnv != "" }
@@ -54,6 +56,10 @@ var, or an interactive no-echo prompt — never as a flag/positional literal
   op read "op://Vault/New Relic/api key" | nrq init --api-key-stdin --account-id 12345 --region US
   nrq init --api-key-from-env NEWRELIC_API_KEY --account-id 12345
 
+  # Fully non-interactive (central installer: op -> env -> --*-from-env)
+  nrq init --region US --api-key-from-env NEWRELIC_API_KEY \
+    --account-id-from-env NEWRELIC_ACCOUNT_ID --non-interactive
+
   # Resolve a one-time migration conflict by forcing the legacy value
   # (no ingress flag — stdin/env would replace the forced legacy value)
   nrq init --overwrite`,
@@ -65,8 +71,10 @@ var, or an interactive no-echo prompt — never as a flag/positional literal
 	cmd.Flags().StringVar(&o.apiKeyEnv, "api-key-from-env", "", "Read the API key from this environment variable")
 	cmd.Flags().BoolVar(&o.apiKeyStdin, "api-key-stdin", false, "Read the API key from stdin")
 	cmd.Flags().StringVar(&o.accountID, "account-id", "", "New Relic account ID (non-secret)")
+	cmd.Flags().StringVar(&o.accountIDEnv, "account-id-from-env", "", "Read the (non-secret) account ID from this environment variable")
 	cmd.Flags().StringVar(&o.region, "region", "", "New Relic region: US or EU (non-secret)")
 	cmd.Flags().BoolVar(&o.overwrite, "overwrite", false, "Resolve a legacy/keyring migration conflict by forcing the legacy value")
+	cmd.Flags().BoolVar(&o.nonInteractive, "non-interactive", false, "Never prompt; fail loudly if a required value is missing (for scripted/installer use)")
 	cmd.Flags().BoolVar(&o.noVerify, "no-verify", false, "Skip connection verification")
 	rootCmd.AddCommand(cmd)
 }
@@ -77,17 +85,23 @@ func runInit(opts *initOptions) error {
 	if opts.apiKeyStdin && opts.apiKeyEnv != "" {
 		return errors.New("provide at most one of --api-key-stdin / --api-key-from-env")
 	}
+	if opts.accountID != "" && opts.accountIDEnv != "" {
+		return errors.New("provide at most one of --account-id / --account-id-from-env")
+	}
+
+	// wantPrompt gates every interactive fallback. --non-interactive forces
+	// fail-loud (cli-deployment-manifest §1.3) so the central installer's
+	// `nrq init` is deterministic regardless of TTY.
+	wantPrompt := !opts.nonInteractive && isTerminal(opts.Stdin)
 
 	// Open the keyring. This runs the one-time §1.8 migration (legacy
 	// keychain / credentials file → keyring + config.yml). --overwrite forces
 	// a legacy value over an existing keyring entry to resolve a conflict.
-	open := keychain.Open
-	if opts.overwrite {
-		open = keychain.OpenForMigrationOverwrite
-	}
-	st, err := open()
+	// The non-interactive policy is plumbed in so the file backend never
+	// prompts for a passphrase on a TTY under --non-interactive.
+	st, err := keychain.OpenForInit(opts.overwrite, opts.nonInteractive)
 	if err != nil {
-		return err // includes the actionable §1.8 conflict error
+		return err // includes the actionable §1.8 conflict / passphrase error
 	}
 	stClosed := false
 	closeStore := func() {
@@ -123,9 +137,9 @@ func runInit(opts *initOptions) error {
 		v.Println("API key already present in the keyring (kept).")
 	default:
 		// No key anywhere and no scripted ingress. Interactive: no-echo
-		// prompt. Non-interactive: a hard, actionable error (never a
-		// silent empty key).
-		if !isTerminal(opts.Stdin) {
+		// prompt. Non-interactive (or non-TTY): a hard, actionable error
+		// (never a silent empty key).
+		if !wantPrompt {
 			return errors.New(
 				"no API key in the keyring and no ingress flag: pass " +
 					"--api-key-stdin or --api-key-from-env NEWRELIC_API_KEY (§1.5.1)")
@@ -146,8 +160,19 @@ func runInit(opts *initOptions) error {
 	if err != nil {
 		return err
 	}
+	// account_id is non-secret: --account-id-from-env reads it from the
+	// named env var (the same op→env→--*-from-env channel the installer
+	// uses for the secret, §1.5.1 shape) but the resolved value goes to
+	// config.yml, NEVER the keyring (§2.5). Empty/unset env is a hard
+	// error, mirroring readSecret's env path.
 	accountID := opts.accountID
-	if accountID == "" && isTerminal(opts.Stdin) {
+	if opts.accountIDEnv != "" {
+		accountID = os.Getenv(opts.accountIDEnv)
+		if accountID == "" {
+			return fmt.Errorf("--account-id-from-env %s is empty or unset", opts.accountIDEnv)
+		}
+	}
+	if accountID == "" && wantPrompt {
 		accountID = prompt(opts, fmt.Sprintf("Account ID [%s]: ", cfg.AccountID))
 	}
 	if accountID != "" {
@@ -157,7 +182,7 @@ func runInit(opts *initOptions) error {
 		cfg.AccountID = accountID
 	}
 	region := opts.region
-	if region == "" && isTerminal(opts.Stdin) {
+	if region == "" && wantPrompt {
 		def := cfg.Region
 		if def == "" {
 			def = config.DefaultRegion

--- a/internal/cmd/me/me.go
+++ b/internal/cmd/me/me.go
@@ -1,0 +1,116 @@
+// Package me implements `nrq me`: a minimal identity / access check used
+// by the central installer's `verify: "me"` step and by humans to confirm
+// their credential resolves. It validates the API key and (when an account
+// is configured) account access, reusing the existing TestConnection API —
+// no new api/ surface. The API key is never printed (§1.12).
+package me
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/newrelic-cli/api"
+	"github.com/open-cli-collective/newrelic-cli/internal/cmd/root"
+	"github.com/open-cli-collective/newrelic-cli/internal/view"
+)
+
+// Register adds the me command to the root command.
+func Register(rootCmd *cobra.Command, opts *root.Options) {
+	cmd := &cobra.Command{
+		Use:   "me",
+		Short: "Show the authenticated user and account (verifies the API key)",
+		Long: `Resolve the API key from the OS keyring and report the
+authenticated New Relic user and, when an account ID is configured, account
+access. Exits non-zero if the key is invalid or the configured account is
+not accessible — so it doubles as a scripted health check. The API key
+itself is never displayed (§1.12).`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runMe(opts)
+		},
+	}
+	rootCmd.AddCommand(cmd)
+}
+
+// identity is the JSON shape. It deliberately has no api_key field — the
+// secret is never serialized (§1.12).
+type identity struct {
+	UserID        string `json:"user_id,omitempty"`
+	UserEmail     string `json:"user_email,omitempty"`
+	AccountID     int    `json:"account_id,omitempty"`
+	AccountName   string `json:"account_name,omitempty"`
+	Region        string `json:"region,omitempty"`
+	APIKeyValid   bool   `json:"api_key_valid"`
+	AccountAccess bool   `json:"account_access"`
+}
+
+func runMe(opts *root.Options) error {
+	// Single credential chokepoint: opts.APIClient() resolves the key from
+	// the keyring and runs the one-time §1.8 migration. No client injection.
+	client, err := opts.APIClient()
+	if err != nil {
+		return err // ErrMissingAPIKey is already actionable, no leak
+	}
+	res, err := client.TestConnection()
+	if err != nil {
+		return err
+	}
+	accountConfigured := !client.AccountID.IsEmpty()
+
+	if rerr := renderMe(opts.View(), res, accountConfigured); rerr != nil {
+		return rerr
+	}
+	return evaluate(res, accountConfigured)
+}
+
+// evaluate is the pure success predicate, mirroring `config test` exactly:
+// a valid key, and — when an account is configured — actual account access.
+// `nrq me` must NOT exit 0 on a valid key with a broken configured account,
+// or the installer's verify:"me" would pass on a misconfigured install.
+// Returned non-nil → non-zero process exit.
+func evaluate(res *api.ConnectionTestResult, accountConfigured bool) error {
+	if !res.APIKeyValid {
+		if res.ErrorMessage != "" {
+			return fmt.Errorf("API key invalid: %s", res.ErrorMessage)
+		}
+		return errors.New("API key invalid or expired")
+	}
+	if accountConfigured && !res.AccountAccess {
+		if res.ErrorMessage != "" {
+			return fmt.Errorf("account not accessible: %s", res.ErrorMessage)
+		}
+		return errors.New("configured account is not accessible with this API key")
+	}
+	return nil
+}
+
+// renderMe is pure (no I/O beyond the View writer): unit-tested directly
+// with synthetic results across table/json/plain. It never emits the
+// api_key (§1.12).
+func renderMe(v *view.View, res *api.ConnectionTestResult, accountConfigured bool) error {
+	id := identity{
+		UserID:        res.UserID,
+		UserEmail:     res.UserEmail,
+		Region:        res.Region,
+		APIKeyValid:   res.APIKeyValid,
+		AccountAccess: res.AccountAccess,
+	}
+	rows := [][]string{
+		{"User ID", res.UserID},
+		{"User email", res.UserEmail},
+		{"Region", res.Region},
+		{"API key valid", fmt.Sprintf("%t", res.APIKeyValid)},
+	}
+	if accountConfigured {
+		id.AccountID = res.AccountID
+		id.AccountName = res.AccountName
+		rows = append(rows,
+			[]string{"Account ID", fmt.Sprintf("%d", res.AccountID)},
+			[]string{"Account name", res.AccountName},
+			[]string{"Account access", fmt.Sprintf("%t", res.AccountAccess)},
+		)
+	}
+	return v.Render([]string{"FIELD", "VALUE"}, rows, id)
+}

--- a/internal/cmd/me/me.go
+++ b/internal/cmd/me/me.go
@@ -26,7 +26,10 @@ authenticated New Relic user and, when an account ID is configured, account
 access. Exits non-zero if the key is invalid or the configured account is
 not accessible — so it doubles as a scripted health check. The API key
 itself is never displayed (§1.12).`,
-		Args: cobra.NoArgs,
+		// Static no-args validator: cobra.NoArgs quotes args[0] in its
+		// error, so `nrq me NRAK-…` would echo a fat-fingered secret to
+		// stderr/logs (§1.12) — the same class fixed for init/set-credential.
+		Args: root.NoPositionalArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runMe(opts)
 		},

--- a/internal/cmd/me/me_test.go
+++ b/internal/cmd/me/me_test.go
@@ -1,0 +1,80 @@
+package me
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/newrelic-cli/api"
+	"github.com/open-cli-collective/newrelic-cli/internal/view"
+)
+
+const apiKeySentinel = "NRAK-SHOULD-NEVER-APPEAR-IN-ME-OUTPUT"
+
+func newView(t *testing.T, f view.Format) (*view.View, *bytes.Buffer) {
+	t.Helper()
+	var out bytes.Buffer
+	v := view.New(&out, &out)
+	v.Format = f
+	return v, &out
+}
+
+// §1.12: no surface (table/json/plain) ever contains the api_key. The
+// ConnectionTestResult has no key field, but pin it so a future field
+// addition can't regress the secret-absence guarantee.
+func TestRenderMe_NeverLeaksAPIKey(t *testing.T) {
+	res := &api.ConnectionTestResult{
+		APIKeyValid: true, AccountAccess: true,
+		UserID: "1234", UserEmail: "u@example.com",
+		AccountID: 42, AccountName: "Acct", Region: "US",
+	}
+	for _, f := range []view.Format{view.FormatTable, view.FormatJSON, view.FormatPlain} {
+		v, out := newView(t, f)
+		require.NoError(t, renderMe(v, res, true))
+		s := out.String()
+		assert.NotContains(t, s, apiKeySentinel)
+		assert.NotContains(t, strings.ToLower(s), "api_key\"")
+		assert.Contains(t, s, "u@example.com", "identity must render (%s)", f)
+	}
+}
+
+// account fields are omitted entirely when no account is configured.
+func TestRenderMe_NoAccountConfigured_OmitsAccountFields(t *testing.T) {
+	res := &api.ConnectionTestResult{APIKeyValid: true, UserID: "1", UserEmail: "x@y.z", Region: "EU"}
+	v, out := newView(t, view.FormatJSON)
+	require.NoError(t, renderMe(v, res, false))
+	s := out.String()
+	assert.NotContains(t, s, "account_id")
+	assert.NotContains(t, s, "account_name")
+	assert.Contains(t, s, "x@y.z")
+}
+
+// evaluate is the scripted health-check predicate the installer relies on.
+func TestEvaluate_Predicate(t *testing.T) {
+	tests := []struct {
+		name              string
+		res               *api.ConnectionTestResult
+		accountConfigured bool
+		wantErr           bool
+	}{
+		{"valid key, no account configured", &api.ConnectionTestResult{APIKeyValid: true}, false, false},
+		{"valid key + account access", &api.ConnectionTestResult{APIKeyValid: true, AccountAccess: true}, true, false},
+		{"valid key but account NOT accessible (configured)", &api.ConnectionTestResult{APIKeyValid: true, AccountAccess: false, ErrorMessage: "no access"}, true, true},
+		{"invalid key", &api.ConnectionTestResult{APIKeyValid: false, ErrorMessage: "bad key"}, false, true},
+		{"invalid key, account configured", &api.ConnectionTestResult{APIKeyValid: false}, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := evaluate(tt.res, tt.accountConfigured)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.NotContains(t, err.Error(), apiKeySentinel)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -47,25 +47,36 @@ type Store struct {
 // The returned Store reads/writes the OS keyring only. A legacy-vs-keyring
 // conflict surfaces here as a §1.8 error; `nrq init --overwrite` calls
 // OpenForMigrationOverwrite to force the legacy value instead.
-func Open() (*Store, error) { return open(false, true) }
+func Open() (*Store, error) { return open(false, true, false) }
 
 // OpenForMigrationOverwrite is Open with the §1.8 `--overwrite` resolution:
 // a legacy value is forced over an existing keyring entry. It still cannot
 // resolve a legacy-vs-legacy disagreement (the user must pick).
-func OpenForMigrationOverwrite() (*Store, error) { return open(true, true) }
+func OpenForMigrationOverwrite() (*Store, error) { return open(true, true, false) }
+
+// OpenForInit is the `nrq init` entry point. It runs the one-time migration
+// like Open (with the §1.8 `--overwrite` resolution when overwrite is set)
+// but additionally carries a non-interactive policy: when nonInteractive,
+// the file-backend passphrase is resolved from the env var only — never an
+// interactive prompt, even on a TTY (cli-deployment-manifest §1.3, so the
+// central installer's `nrq init --non-interactive` is deterministic). Other
+// callers' Open* entry points are unchanged.
+func OpenForInit(overwrite, nonInteractive bool) (*Store, error) {
+	return open(overwrite, true, nonInteractive)
+}
 
 // OpenNoMigrate opens the store WITHOUT running the one-time migration. It
 // exists so `config clear` can perform the §1.8 conflict remediation it
 // advertises: if migration ran first it would return the conflict error
 // before clear could delete the keyring entry, leaving the user no way out.
-func OpenNoMigrate() (*Store, error) { return open(false, false) }
+func OpenNoMigrate() (*Store, error) { return open(false, false, false) }
 
-func open(overwrite, runMigration bool) (*Store, error) {
+func open(overwrite, runMigration, nonInteractive bool) (*Store, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, err
 	}
-	return openWith(cfg, overwrite, runMigration)
+	return openWith(cfg, overwrite, runMigration, nonInteractive)
 }
 
 // OpenRef opens a store against an explicit ref instead of config.yml's
@@ -82,13 +93,13 @@ func OpenRef(ref string) (*Store, error) {
 	if ref != "" {
 		cfg.CredentialRef = ref
 	}
-	return openWith(cfg, false, false)
+	return openWith(cfg, false, false, false)
 }
 
 // openWith is the seam unit tests drive with an injected config (e.g. a
 // file-backend opt-in via Keyring.Backend) so they never touch a real
 // keyring (§1.12 test obligation, and hermeticity).
-func openWith(cfg *config.Config, overwrite, runMigration bool) (*Store, error) {
+func openWith(cfg *config.Config, overwrite, runMigration, nonInteractive bool) (*Store, error) {
 	service, profile, err := credstore.ParseRef(cfg.CredentialRef)
 	if err != nil {
 		return nil, fmt.Errorf("invalid credential_ref %q: %w", cfg.CredentialRef, err)
@@ -105,7 +116,7 @@ func openWith(cfg *config.Config, overwrite, runMigration bool) (*Store, error) 
 		// auto-selection and store credentials somewhere unintended.
 		return nil, fmt.Errorf("invalid keyring.backend %q in config (only \"file\" is supported)", b)
 	}
-	opts.FilePassphrase = passphraseFunc(service)
+	opts.FilePassphrase = passphraseFunc(service, nonInteractive)
 
 	cs, err := credstore.Open(service, opts)
 	if err != nil {

--- a/internal/keychain/migrate_test.go
+++ b/internal/keychain/migrate_test.go
@@ -260,7 +260,7 @@ func TestAPIKey_EmptyStored_DistinctFromMissing(t *testing.T) {
 	t.Setenv(legacyKeychainScanDisabledEnv, "1")
 
 	cfg := &config.Config{CredentialRef: "newrelic-cli/default"}
-	st, err := openWith(cfg, false, false)
+	st, err := openWith(cfg, false, false, false)
 	require.NoError(t, err)
 	defer func() { _ = st.Close() }()
 
@@ -291,7 +291,7 @@ func TestRepairContract_EmptyEntry_OverwriteRepairs(t *testing.T) {
 	t.Setenv(legacyKeychainScanDisabledEnv, "1")
 
 	cfg := &config.Config{CredentialRef: "newrelic-cli/default"}
-	st, err := openWith(cfg, false, false)
+	st, err := openWith(cfg, false, false, false)
 	require.NoError(t, err)
 	defer func() { _ = st.Close() }()
 
@@ -380,6 +380,18 @@ func TestScrubLegacyKeychain_AttemptsAllAccounts(t *testing.T) {
 	require.Error(t, err)
 	assert.ElementsMatch(t, append([]string{secretField}, nonSecretFields...), deleted,
 		"a failure on one account must not strand the others")
+}
+
+// INT-444 S2 (Codex blocker): under --non-interactive the file-backend
+// passphrase callback must NEVER prompt — even on a TTY — and instead fail
+// loud naming the env var. The keychain opens before runInit's own prompt
+// guards, so this policy must live here.
+func TestPassphraseFunc_NonInteractive_NeverPrompts(t *testing.T) {
+	f := passphraseFunc("newrelic-cli", true)
+	_, err := f()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NEWRELIC_CLI_KEYRING_PASSPHRASE")
+	assert.Contains(t, err.Error(), "non-interactive")
 }
 
 func TestConflictErr_NoValueLeak(t *testing.T) {

--- a/internal/keychain/passphrase.go
+++ b/internal/keychain/passphrase.go
@@ -22,12 +22,21 @@ func passphraseEnvVar(service string) string {
 // a no-echo TTY prompt. Headless with no env var set is a hard, actionable
 // error — never a silent empty passphrase (that would create an
 // effectively-unencrypted keyring).
-func passphraseFunc(service string) func() (string, error) {
+//
+// When nonInteractive is set (`nrq init --non-interactive`) the prompt is
+// suppressed even on a TTY: the passphrase must come from the env var or
+// the call fails loud, so the installer's non-interactive init is
+// deterministic (cli-deployment-manifest §1.3).
+func passphraseFunc(service string, nonInteractive bool) func() (string, error) {
 	return func() (string, error) {
-		if !term.IsTerminal(int(os.Stdin.Fd())) {
+		if nonInteractive || !term.IsTerminal(int(os.Stdin.Fd())) {
+			hint := ", or run interactively"
+			if nonInteractive {
+				hint = " (required with --non-interactive)"
+			}
 			return "", fmt.Errorf(
-				"file keyring backend needs a passphrase: set %s, or run interactively",
-				passphraseEnvVar(service))
+				"file keyring backend needs a passphrase: set %s%s",
+				passphraseEnvVar(service), hint)
 		}
 		fmt.Fprintf(os.Stderr, "Passphrase for the %s file keyring: ", service)
 		b, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/internal/noleak/noleak_test.go
+++ b/internal/noleak/noleak_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/configcmd"
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/initcmd"
+	"github.com/open-cli-collective/newrelic-cli/internal/cmd/me"
 	"github.com/open-cli-collective/newrelic-cli/internal/cmd/root"
 	"github.com/open-cli-collective/newrelic-cli/internal/config"
 	"github.com/open-cli-collective/newrelic-cli/internal/keychain"
@@ -596,6 +597,24 @@ func TestInit_AccountIDFromEnv_Errors(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "at most one of --account-id")
 	})
+}
+
+// INT-444 (Codex PR Major): `nrq me` must not echo a fat-fingered
+// positional secret — same §1.12 class fixed for init/set-credential.
+func TestNoLeak_Me_PositionalArgRejected(t *testing.T) {
+	testutil.Setup(t)
+	rootCmd, opts := root.NewRootCmd()
+	var o, e bytes.Buffer
+	opts.Stdout, opts.Stderr = &o, &e
+	rootCmd.SetOut(&o)
+	rootCmd.SetErr(&e)
+	root.RegisterAll(rootCmd, opts, me.Register)
+	rootCmd.SetArgs([]string{"me", sentinel})
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.NotContains(t, o.String()+e.String(), sentinel)
+	assert.NotContains(t, err.Error(), sentinel)
+	assert.Contains(t, err.Error(), "no positional arguments")
 }
 
 // INT-444 S2: --non-interactive with no key and no ingress flag fails loud

--- a/internal/noleak/noleak_test.go
+++ b/internal/noleak/noleak_test.go
@@ -533,3 +533,81 @@ func TestInit_NoSecretInConfigYML(t *testing.T) {
 	assert.NotContains(t, string(raw), sentinel)
 	assert.Contains(t, string(raw), "account_id: \"42\"")
 }
+
+// INT-444 S1: --account-id-from-env reads the NON-secret account_id from a
+// named env var (installer op→env→--*-from-env channel) and writes it to
+// config.yml — never the keyring. End-to-end installer invocation.
+func TestInit_AccountIDFromEnv_InstallerInvocation(t *testing.T) {
+	testutil.Setup(t)
+	t.Setenv("NRQ_INSTALLER_KEY", sentinel)
+	t.Setenv("NRQ_INSTALLER_ACCT", "98765")
+	rootCmd, opts := root.NewRootCmd()
+	var o, e bytes.Buffer
+	opts.Stdout, opts.Stderr = &o, &e
+	root.RegisterAll(rootCmd, opts, initcmd.Register)
+	rootCmd.SetArgs([]string{"init", "--region", "US",
+		"--api-key-from-env", "NRQ_INSTALLER_KEY",
+		"--account-id-from-env", "NRQ_INSTALLER_ACCT",
+		"--non-interactive", "--no-verify"})
+	require.NoError(t, rootCmd.Execute())
+	assert.NotContains(t, o.String()+e.String(), sentinel)
+
+	raw, err := os.ReadFile(config.Path())
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), sentinel, "secret never in config.yml")
+	assert.Contains(t, string(raw), "account_id: \"98765\"")
+	assert.Contains(t, string(raw), "region: US")
+
+	st, err := keychain.OpenNoMigrate()
+	require.NoError(t, err)
+	defer func() { _ = st.Close() }()
+	got, _ := st.APIKey()
+	assert.Equal(t, sentinel, got, "api_key in keyring")
+}
+
+// INT-444 S1: an empty/unset --account-id-from-env var is a hard error
+// (mirrors --api-key-from-env), and the two account flags are mutually
+// exclusive.
+func TestInit_AccountIDFromEnv_Errors(t *testing.T) {
+	t.Run("empty/unset env", func(t *testing.T) {
+		testutil.Setup(t)
+		t.Setenv("NRQ_K", sentinel)
+		rootCmd, opts := root.NewRootCmd()
+		var o, e bytes.Buffer
+		opts.Stdout, opts.Stderr = &o, &e
+		root.RegisterAll(rootCmd, opts, initcmd.Register)
+		rootCmd.SetArgs([]string{"init", "--api-key-from-env", "NRQ_K",
+			"--account-id-from-env", "NRQ_DEFINITELY_UNSET", "--non-interactive", "--no-verify"})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "is empty or unset")
+	})
+	t.Run("mutually exclusive with --account-id", func(t *testing.T) {
+		testutil.Setup(t)
+		t.Setenv("NRQ_K", sentinel)
+		t.Setenv("NRQ_A", "42")
+		rootCmd, opts := root.NewRootCmd()
+		var o, e bytes.Buffer
+		opts.Stdout, opts.Stderr = &o, &e
+		root.RegisterAll(rootCmd, opts, initcmd.Register)
+		rootCmd.SetArgs([]string{"init", "--api-key-from-env", "NRQ_K",
+			"--account-id", "1", "--account-id-from-env", "NRQ_A", "--no-verify"})
+		err := rootCmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at most one of --account-id")
+	})
+}
+
+// INT-444 S2: --non-interactive with no key and no ingress flag fails loud
+// (never hangs on a prompt), naming the ingress flags.
+func TestInit_NonInteractive_NoKeyNoIngress_FailsLoud(t *testing.T) {
+	testutil.Setup(t)
+	rootCmd, opts := root.NewRootCmd()
+	var o, e bytes.Buffer
+	opts.Stdout, opts.Stderr = &o, &e
+	root.RegisterAll(rootCmd, opts, initcmd.Register)
+	rootCmd.SetArgs([]string{"init", "--non-interactive", "--no-verify"})
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no API key in the keyring and no ingress flag")
+}


### PR DESCRIPTION
Lets the central installer (`~/monit/claude-desktop-mcp`) drive `nrq init` non-interactively from `installer-config.json` (1Password refs → `op run` → env → `--*-from-env`).

Closes #96 · INT-444 (child of INT-310). Per maintainer fast-follow directive: single PR, **no daemon / no TDD-assessment**, Codex architect convergence (plan loop 0/0 over 2 rounds; one PR re-review) then admin-merge.

## Changes
- **`nrq init --account-id-from-env <ENV>`** — env-bridge for the **non-secret** account_id: same `op→env→--*-from-env` shape as `--api-key-from-env` (§1.5.1), but the resolved value lands in `config.yml`, **never the keyring** (§2.5). Mutually exclusive with `--account-id`; empty/unset env is a hard error (mirrors `--api-key-from-env`).
- **`nrq init --non-interactive`** (init-only) — every interactive fallback becomes fail-loud (cli-deployment-manifest §1.3). Critically, the policy is threaded through a new `keychain.OpenForInit(overwrite, nonInteractive)` → `passphraseFunc(service, nonInteractive)` so the **file backend never prompts for a passphrase even on a TTY** (the keychain opens *before* runInit's own prompt guards — caught by Codex as a blocker on the plan). Other `Open*` entry points unchanged.
- **`nrq me`** — minimal identity/access check **reusing `TestConnection`** (no new `api/` surface). `RunE` stays hardwired through `opts.APIClient()` (single credential chokepoint, no client injection); the pure `evaluate()` success predicate mirrors `config test` exactly (valid key AND, when an account is configured, account access) so the installer's `verify: "me"` cannot pass on a misconfigured account. The api_key is never rendered (§1.12).

## Tests
`--account-id-from-env` installer-invocation e2e (config.yml set, keyring holds only api_key); empty-env + mutually-exclusive errors; `--non-interactive` no-key/no-ingress fail-loud; `passphraseFunc(_, true)` never-prompts (keychain unit, the Codex-blocker pin); `renderMe` table/json/plain with no key leak; `evaluate()` predicate table. No test makes a live New Relic call (init uses `--no-verify`; `me` logic tested via pure helpers).

Gate: gofmt · build · vet · **430 `-race` tests** (29 pkgs) · `go mod tidy` no-drift · golangci-lint v2.0.2 0 issues · go 1.24.0.