### PR TITLE
chore(deps): bump cli-common to v0.1.0 [MON-5375]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/fatih/color v1.18.0
-	github.com/open-cli-collective/cli-common v0.0.0-20260519134256-e67b2fc81f9d
+	github.com/open-cli-collective/cli-common v0.1.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/term v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-cli-collective/cli-common v0.0.0-20260519134256-e67b2fc81f9d h1:fiyfxc/Wvpuen/u6Mk3bCUG0DLyOylF0K+eol4y9C64=
-github.com/open-cli-collective/cli-common v0.0.0-20260519134256-e67b2fc81f9d/go.mod h1:5i4MkFToMVPLBW29O01lsHS9d1m9pC0BxSOYjFDz7ds=
+github.com/open-cli-collective/cli-common v0.1.0 h1:BhdwBZhTaPeMi/2aRWzbuzNitImgn1ft7ahQqoul6qE=
+github.com/open-cli-collective/cli-common v0.1.0/go.mod h1:5i4MkFToMVPLBW29O01lsHS9d1m9pC0BxSOYjFDz7ds=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
INT-310 state layer first stable tag — coordinated release train per cli-common docs/working-with-state.md §6 step 6 (cli-common@e48c73e, tag v0.1.0).

No behavior change: v0.1.0's loadable package set is identical to e67b2fc81f9d (the candidate SHA all 5 ports merged against) plus the doc-only retrospective commits. 450 tests pass; make verify all green.

Part of MON-5375 train: atlassian-cli + google-readonly + slack-chat-api + this. sfdc parked (MON-5374).