### PR TITLE
feat(set-credential): add --json envelope; strict --ref defaulting

### DIFF
--- a/internal/cmd/configcmd/config.go
+++ b/internal/cmd/configcmd/config.go
@@ -59,15 +59,17 @@ type setCredentialOptions struct {
 // setCredentialEnvelope is the §1.5.2 / §1.8 control-plane response shape
 // emitted on stdout when --json is set. backend is empty when the keyring
 // store was never opened (pre-keyring failure). error is omitted on success.
-// warning is omitted unless API-key validation flagged a non-fatal caveat
-// (e.g., a non-standard key prefix) — automation consumers need a
-// machine-readable surface for those signals since stderr is silenced.
+//
+// Schema deliberately matches §1.5.2 verbatim (ref/key/backend/written/error)
+// so this implementation is the reference shape for jtk/cfl (atlassian-cli
+// #389) and sfdc (#43). No optional extensions — non-fatal validation
+// warnings (e.g. non-standard key prefix) are dropped under --json since
+// stderr is silenced; the human path retains the v.Warning() surface.
 type setCredentialEnvelope struct {
 	Ref     string `json:"ref"`
 	Key     string `json:"key"`
 	Backend string `json:"backend"`
 	Written bool   `json:"written"`
-	Warning string `json:"warning,omitempty"`
 	Error   string `json:"error,omitempty"`
 }
 
@@ -184,15 +186,13 @@ func runSetCredential(o *setCredentialOptions) error {
 			return preKeyringFail(fmt.Errorf("environment variable %s is empty or unset", o.fromEnv))
 		}
 	}
-	var apiKeyWarning string
 	if warning, err := validate.APIKey(secret); err != nil {
 		return preKeyringFail(err)
-	} else if warning != "" {
-		if o.json {
-			apiKeyWarning = warning // surfaced via envelope.Warning below
-		} else {
-			v.Warning("%s", warning)
-		}
+	} else if warning != "" && !o.json {
+		// Under --json the envelope is the only diagnostic surface, and the
+		// §1.5.2 schema doesn't include a warning field — drop non-fatal
+		// validation caveats rather than expand the schema unilaterally.
+		v.Warning("%s", warning)
 	}
 
 	st, err := keychain.OpenRef(o.ref) // pure ingress: no migration
@@ -211,7 +211,6 @@ func runSetCredential(o *setCredentialOptions) error {
 				Key:     o.key,
 				Backend: storeBackendName(st),
 				Written: false,
-				Warning: apiKeyWarning,
 				Error:   err.Error(),
 			})
 		}
@@ -241,7 +240,6 @@ func runSetCredential(o *setCredentialOptions) error {
 			Key:     o.key,
 			Backend: storeBackendName(st),
 			Written: true,
-			Warning: apiKeyWarning,
 		})
 	}
 	v.Success("Stored %s in the OS keyring at %s", o.key, st.Ref())

--- a/internal/cmd/configcmd/config.go
+++ b/internal/cmd/configcmd/config.go
@@ -211,6 +211,7 @@ func runSetCredential(o *setCredentialOptions) error {
 				Key:     o.key,
 				Backend: storeBackendName(st),
 				Written: false,
+				Warning: apiKeyWarning,
 				Error:   err.Error(),
 			})
 		}

--- a/internal/cmd/configcmd/config.go
+++ b/internal/cmd/configcmd/config.go
@@ -84,11 +84,20 @@ Examples (--ref is required when no config.yml exists — §1.5.2; once
   nrq set-credential --key api_key --stdin   # after 'nrq init' has created config.yml`,
 		Args: root.NoPositionalArgs, // never echo a fat-fingered secret (§1.12)
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Honor both the subcommand-local --json AND the root --output json
+			// / deprecated root --json (root.go:140-147). Without this, the
+			// effective behavior would be order-dependent — `nrq --json
+			// set-credential` would bypass the envelope while
+			// `nrq set-credential --json` would emit it. Normalize so the
+			// rest of runSetCredential has a single switch.
+			if o.Output == "json" {
+				o.json = true
+			}
 			if o.json {
 				// §1.5.2: emit envelope on stdout; suppress cobra's stderr
 				// auto-print so the only thing on stderr is the envelope's
-				// counterpart (nothing in the success case; nothing on
-				// failure either — the JSON envelope is the failure signal).
+				// counterpart (nothing on success or failure — the JSON
+				// envelope is the failure signal).
 				cmd.SilenceErrors = true
 				cmd.SilenceUsage = true
 			}
@@ -110,7 +119,9 @@ func runSetCredential(o *setCredentialOptions) error {
 	// Pre-keyring phase: failures here have no backend/ref resolved yet.
 	preKeyringFail := func(err error) error {
 		if o.json {
-			emitSetCredentialEnvelope(o, setCredentialEnvelope{
+			// On failure paths, the original error is the primary signal;
+			// a broken-pipe write error on the envelope would only obscure it.
+			_ = emitSetCredentialEnvelope(o, setCredentialEnvelope{
 				Ref:     o.ref, // may be empty if user omitted it
 				Key:     o.key,
 				Backend: "",
@@ -178,7 +189,9 @@ func runSetCredential(o *setCredentialOptions) error {
 	// Post-keyring phase: ref and backend are now populated from the open store.
 	postKeyringFail := func(err error) error {
 		if o.json {
-			emitSetCredentialEnvelope(o, setCredentialEnvelope{
+			// On failure paths, the original error is the primary signal;
+			// a broken-pipe write error on the envelope would only obscure it.
+			_ = emitSetCredentialEnvelope(o, setCredentialEnvelope{
 				Ref:     st.Ref(),
 				Key:     o.key,
 				Backend: storeBackendName(st),
@@ -207,13 +220,12 @@ func runSetCredential(o *setCredentialOptions) error {
 	}
 
 	if o.json {
-		emitSetCredentialEnvelope(o, setCredentialEnvelope{
+		return emitSetCredentialEnvelope(o, setCredentialEnvelope{
 			Ref:     st.Ref(),
 			Key:     o.key,
 			Backend: storeBackendName(st),
 			Written: true,
 		})
-		return nil
 	}
 	v.Success("Stored %s in the OS keyring at %s", o.key, st.Ref())
 	return nil
@@ -222,10 +234,15 @@ func runSetCredential(o *setCredentialOptions) error {
 // emitSetCredentialEnvelope writes a §1.5.2 / §1.8 control-plane envelope to
 // stdout. The secret value is never included by construction — the envelope
 // struct has no field for it. Tests assert §1.12 absence-of-value across
-// every failure path.
-func emitSetCredentialEnvelope(o *setCredentialOptions, env setCredentialEnvelope) {
+// every failure path. Returns any stdout write error so the caller surfaces
+// a broken pipe (otherwise a successful keyring write would exit 0 without
+// the envelope ever reaching the consumer).
+func emitSetCredentialEnvelope(o *setCredentialOptions, env setCredentialEnvelope) error {
 	enc := json.NewEncoder(o.Stdout)
-	_ = enc.Encode(env)
+	if err := enc.Encode(env); err != nil {
+		return fmt.Errorf("emit set-credential envelope: %w", err)
+	}
+	return nil
 }
 
 // storeBackendName extracts the credstore.Backend name from the open store,

--- a/internal/cmd/configcmd/config.go
+++ b/internal/cmd/configcmd/config.go
@@ -6,6 +6,7 @@
 package configcmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -52,6 +53,18 @@ type setCredentialOptions struct {
 	stdin     bool
 	fromEnv   string
 	overwrite bool
+	json      bool
+}
+
+// setCredentialEnvelope is the §1.5.2 / §1.8 control-plane response shape
+// emitted on stdout when --json is set. backend is empty when the keyring
+// store was never opened (pre-keyring failure). error is omitted on success.
+type setCredentialEnvelope struct {
+	Ref     string `json:"ref"`
+	Key     string `json:"key"`
+	Backend string `json:"backend"`
+	Written bool   `json:"written"`
+	Error   string `json:"error,omitempty"`
 }
 
 func newSetCredentialCmd(opts *root.Options) *cobra.Command {
@@ -64,43 +77,76 @@ path (§1.5.2). It writes one key to the OS keyring. The value is read from
 stdin or a named environment variable — NEVER from a flag or positional
 argument (those leak via ps / shell history).
 
-Examples:
-  op read "op://Vault/New Relic/api key" | nrq set-credential --key api_key --stdin
-  nrq set-credential --key api_key --from-env NEWRELIC_API_KEY
-  nrq set-credential --ref newrelic-cli/default --key api_key --stdin`,
+Examples (--ref is required when no config.yml exists — §1.5.2; once
+'nrq init' has run, --ref defaults to the active config's credential_ref):
+  op read "op://Vault/New Relic/api key" | nrq set-credential --ref newrelic-cli/default --key api_key --stdin
+  nrq set-credential --ref newrelic-cli/default --key api_key --from-env NEWRELIC_API_KEY
+  nrq set-credential --key api_key --stdin   # after 'nrq init' has created config.yml`,
 		Args: root.NoPositionalArgs, // never echo a fat-fingered secret (§1.12)
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if o.json {
+				// §1.5.2: emit envelope on stdout; suppress cobra's stderr
+				// auto-print so the only thing on stderr is the envelope's
+				// counterpart (nothing in the success case; nothing on
+				// failure either — the JSON envelope is the failure signal).
+				cmd.SilenceErrors = true
+				cmd.SilenceUsage = true
+			}
 			return runSetCredential(o)
 		},
 	}
-	cmd.Flags().StringVar(&o.ref, "ref", "", "Credential ref (default: config.yml credential_ref)")
+	cmd.Flags().StringVar(&o.ref, "ref", "", "Credential ref (required when no config.yml; defaults to active config's credential_ref otherwise — §1.5.2)")
 	cmd.Flags().StringVar(&o.key, "key", "", "Bundle key to set (only \"api_key\" is allowed)")
 	cmd.Flags().BoolVar(&o.stdin, "stdin", false, "Read the secret value from stdin")
 	cmd.Flags().StringVar(&o.fromEnv, "from-env", "", "Read the secret value from this environment variable")
 	cmd.Flags().BoolVar(&o.overwrite, "overwrite", false, "Replace an existing keyring value (refuses by default)")
+	cmd.Flags().BoolVar(&o.json, "json", false, "Emit a §1.5.2/§1.8 control-plane envelope on stdout instead of human text")
 	return cmd
 }
 
 func runSetCredential(o *setCredentialOptions) error {
 	v := o.View()
 
+	// Pre-keyring phase: failures here have no backend/ref resolved yet.
+	preKeyringFail := func(err error) error {
+		if o.json {
+			emitSetCredentialEnvelope(o, setCredentialEnvelope{
+				Ref:     o.ref, // may be empty if user omitted it
+				Key:     o.key,
+				Backend: "",
+				Written: false,
+				Error:   err.Error(),
+			})
+		}
+		return err
+	}
+
 	if o.key != keychain.KeyAPIKey {
-		return fmt.Errorf("unsupported --key %q: nrq's only bundle key is %q (§1.5.2)",
-			o.key, keychain.KeyAPIKey)
+		return preKeyringFail(fmt.Errorf("unsupported --key %q: nrq's only bundle key is %q (§1.5.2)",
+			o.key, keychain.KeyAPIKey))
 	}
 	if o.stdin == (o.fromEnv != "") {
-		return errors.New("provide exactly one of --stdin or --from-env (the value is never a flag/positional — §1.5)")
+		return preKeyringFail(errors.New("provide exactly one of --stdin or --from-env (the value is never a flag/positional — §1.5)"))
 	}
-	// --ref is optional: when omitted, OpenRef("") inherits config.yml's
-	// credential_ref, or DefaultCredentialRef when there is no config.yml
-	// (the §1.10 fresh-install automation primitive — `op read | nrq
-	// set-credential --key api_key --stdin` must work with no prior
-	// config). When provided, validate it up front so an invalid value
-	// fails with a message naming the --ref flag, not deep inside OpenRef.
 	if o.ref != "" {
 		if _, _, err := credstore.ParseRef(o.ref); err != nil {
-			return fmt.Errorf("invalid --ref %q: %w (expected <service>/<profile>, e.g. %s)",
-				o.ref, err, config.DefaultCredentialRef)
+			return preKeyringFail(fmt.Errorf("invalid --ref %q: %w (expected <service>/<profile>, e.g. %s)",
+				o.ref, err, config.DefaultCredentialRef))
+		}
+	} else {
+		// §1.5.2 strict: --ref defaults to the active config's credential_ref
+		// ONLY when a config file already exists. Absent any config, the
+		// fresh-install caller must pass --ref explicitly.
+		has, herr := config.HasUserConfig()
+		if herr != nil {
+			return preKeyringFail(fmt.Errorf("probe config presence: %w", herr))
+		}
+		if !has {
+			return preKeyringFail(fmt.Errorf(
+				"no config.yml found and --ref omitted; pass --ref %s "+
+					"(or run 'nrq init' first to create config.yml) — §1.5.2 "+
+					"requires --ref when there is no active config to default from",
+				config.DefaultCredentialRef))
 		}
 	}
 
@@ -108,31 +154,45 @@ func runSetCredential(o *setCredentialOptions) error {
 	if o.stdin {
 		b, err := io.ReadAll(o.Stdin)
 		if err != nil {
-			return fmt.Errorf("read secret from stdin: %w", err)
+			return preKeyringFail(fmt.Errorf("read secret from stdin: %w", err))
 		}
 		secret = strings.TrimRight(string(b), "\r\n")
 	} else {
 		secret = os.Getenv(o.fromEnv)
 		if secret == "" {
-			return fmt.Errorf("environment variable %s is empty or unset", o.fromEnv)
+			return preKeyringFail(fmt.Errorf("environment variable %s is empty or unset", o.fromEnv))
 		}
 	}
 	if warning, err := validate.APIKey(secret); err != nil {
-		return err
-	} else if warning != "" {
+		return preKeyringFail(err)
+	} else if warning != "" && !o.json {
 		v.Warning("%s", warning)
 	}
 
 	st, err := keychain.OpenRef(o.ref) // pure ingress: no migration
 	if err != nil {
-		return err
+		return preKeyringFail(err)
 	}
 	defer func() { _ = st.Close() }()
+
+	// Post-keyring phase: ref and backend are now populated from the open store.
+	postKeyringFail := func(err error) error {
+		if o.json {
+			emitSetCredentialEnvelope(o, setCredentialEnvelope{
+				Ref:     st.Ref(),
+				Key:     o.key,
+				Backend: storeBackendName(st),
+				Written: false,
+				Error:   err.Error(),
+			})
+		}
+		return err
+	}
 
 	// No-clobber by default (§1.5/§1.11): an existing keyring value is never
 	// silently replaced — the user must pass --overwrite.
 	if st.HasAPIKey() && !o.overwrite {
-		return fmt.Errorf("%s already set at %s; pass --overwrite to replace it", o.key, st.Ref())
+		return postKeyringFail(fmt.Errorf("%s already set at %s; pass --overwrite to replace it", o.key, st.Ref()))
 	}
 	if o.overwrite {
 		err = st.SetAPIKeyOverwrite(secret)
@@ -141,12 +201,39 @@ func runSetCredential(o *setCredentialOptions) error {
 	}
 	if err != nil {
 		if errors.Is(err, credstore.ErrExists) {
-			return fmt.Errorf("%s already set at %s; pass --overwrite to replace it", o.key, st.Ref())
+			return postKeyringFail(fmt.Errorf("%s already set at %s; pass --overwrite to replace it", o.key, st.Ref()))
 		}
-		return err
+		return postKeyringFail(err)
+	}
+
+	if o.json {
+		emitSetCredentialEnvelope(o, setCredentialEnvelope{
+			Ref:     st.Ref(),
+			Key:     o.key,
+			Backend: storeBackendName(st),
+			Written: true,
+		})
+		return nil
 	}
 	v.Success("Stored %s in the OS keyring at %s", o.key, st.Ref())
 	return nil
+}
+
+// emitSetCredentialEnvelope writes a §1.5.2 / §1.8 control-plane envelope to
+// stdout. The secret value is never included by construction — the envelope
+// struct has no field for it. Tests assert §1.12 absence-of-value across
+// every failure path.
+func emitSetCredentialEnvelope(o *setCredentialOptions, env setCredentialEnvelope) {
+	enc := json.NewEncoder(o.Stdout)
+	_ = enc.Encode(env)
+}
+
+// storeBackendName extracts the credstore.Backend name from the open store,
+// discarding the Source — JSON envelope consumers care only about which
+// backend resolved (file vs keychain vs ...), not how it was selected.
+func storeBackendName(st *keychain.Store) string {
+	b, _ := st.Backend()
+	return string(b)
 }
 
 // ---- config set / aliases (non-secret config.yml) --------------------------

--- a/internal/cmd/configcmd/config.go
+++ b/internal/cmd/configcmd/config.go
@@ -59,11 +59,15 @@ type setCredentialOptions struct {
 // setCredentialEnvelope is the §1.5.2 / §1.8 control-plane response shape
 // emitted on stdout when --json is set. backend is empty when the keyring
 // store was never opened (pre-keyring failure). error is omitted on success.
+// warning is omitted unless API-key validation flagged a non-fatal caveat
+// (e.g., a non-standard key prefix) — automation consumers need a
+// machine-readable surface for those signals since stderr is silenced.
 type setCredentialEnvelope struct {
 	Ref     string `json:"ref"`
 	Key     string `json:"key"`
 	Backend string `json:"backend"`
 	Written bool   `json:"written"`
+	Warning string `json:"warning,omitempty"`
 	Error   string `json:"error,omitempty"`
 }
 
@@ -159,6 +163,12 @@ func runSetCredential(o *setCredentialOptions) error {
 					"requires --ref when there is no active config to default from",
 				config.DefaultCredentialRef))
 		}
+		// Resolve the active credential_ref so a downstream OpenRef failure
+		// surfaces a useful Ref value in the envelope (otherwise the JSON
+		// consumer can't tell which ref was attempted).
+		if cfg, cerr := config.Load(); cerr == nil && cfg.CredentialRef != "" {
+			o.ref = cfg.CredentialRef
+		}
 	}
 
 	var secret string
@@ -174,10 +184,15 @@ func runSetCredential(o *setCredentialOptions) error {
 			return preKeyringFail(fmt.Errorf("environment variable %s is empty or unset", o.fromEnv))
 		}
 	}
+	var apiKeyWarning string
 	if warning, err := validate.APIKey(secret); err != nil {
 		return preKeyringFail(err)
-	} else if warning != "" && !o.json {
-		v.Warning("%s", warning)
+	} else if warning != "" {
+		if o.json {
+			apiKeyWarning = warning // surfaced via envelope.Warning below
+		} else {
+			v.Warning("%s", warning)
+		}
 	}
 
 	st, err := keychain.OpenRef(o.ref) // pure ingress: no migration
@@ -225,6 +240,7 @@ func runSetCredential(o *setCredentialOptions) error {
 			Key:     o.key,
 			Backend: storeBackendName(st),
 			Written: true,
+			Warning: apiKeyWarning,
 		})
 	}
 	v.Success("Stored %s in the OS keyring at %s", o.key, st.Ref())

--- a/internal/cmd/configcmd/set_credential_test.go
+++ b/internal/cmd/configcmd/set_credential_test.go
@@ -1,0 +1,274 @@
+package configcmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/newrelic-cli/internal/cmd/root"
+	"github.com/open-cli-collective/newrelic-cli/internal/config"
+	"github.com/open-cli-collective/newrelic-cli/internal/keychain"
+	"github.com/open-cli-collective/newrelic-cli/internal/testutil"
+)
+
+// secretSentinel is a recognizable string that must never appear in any
+// captured stdout / stderr / envelope, per §1.12.
+const secretSentinel = "NRAK-DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEAD"
+
+// runSetCredentialViaRoot executes `nrq set-credential <args>` end-to-end
+// through the root command so this exercises cobra flag parsing, the
+// PersistentPreRunE chain (incl. SilenceErrors wiring), and stdout/stderr
+// routing — not just the inner runSetCredential function.
+func runSetCredentialViaRoot(t *testing.T, stdin string, args ...string) (stdout, stderr *bytes.Buffer, err error) {
+	t.Helper()
+	rootCmd, opts := root.NewRootCmd()
+	stdout = &bytes.Buffer{}
+	stderr = &bytes.Buffer{}
+	opts.Stdout, opts.Stderr = stdout, stderr
+	opts.Stdin = strings.NewReader(stdin)
+	root.RegisterAll(rootCmd, opts, Register)
+	rootCmd.SetArgs(append([]string{"set-credential"}, args...))
+	err = rootCmd.Execute()
+	return stdout, stderr, err
+}
+
+// parseEnvelope decodes the single JSON line emitted on stdout.
+func parseEnvelope(t *testing.T, stdout *bytes.Buffer) setCredentialEnvelope {
+	t.Helper()
+	var env setCredentialEnvelope
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &env), "stdout is not a valid JSON envelope:\n%s", stdout.String())
+	return env
+}
+
+// --- JSON envelope tests ----------------------------------------------------
+
+func TestSetCredential_JSONSuccess(t *testing.T) {
+	testutil.Setup(t)
+	stdout, stderr, err := runSetCredentialViaRoot(t,
+		secretSentinel+"\n",
+		"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin", "--json")
+	require.NoError(t, err)
+
+	env := parseEnvelope(t, stdout)
+	assert.Equal(t, "newrelic-cli/test", env.Ref)
+	assert.Equal(t, "api_key", env.Key)
+	assert.NotEmpty(t, env.Backend, "post-keyring success must populate backend")
+	assert.True(t, env.Written)
+	assert.Empty(t, env.Error)
+
+	// Stderr empty — no human Success() line when --json.
+	assert.Empty(t, stderr.String(), "stderr must be empty on --json success")
+
+	// §1.12: never leak the secret on any captured stream.
+	assert.NotContains(t, stdout.String()+stderr.String(), secretSentinel)
+}
+
+func TestSetCredential_JSONFailure_ExistingKey_PostKeyring(t *testing.T) {
+	testutil.Setup(t)
+	// Seed an existing value.
+	_, _, err := runSetCredentialViaRoot(t,
+		secretSentinel+"\n",
+		"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin")
+	require.NoError(t, err)
+
+	// Re-run without --overwrite; expect post-keyring failure envelope.
+	stdout, stderr, err := runSetCredentialViaRoot(t,
+		"NRAK-other-value\n",
+		"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin", "--json")
+	require.Error(t, err, "exit must be non-zero on no-clobber failure")
+
+	env := parseEnvelope(t, stdout)
+	assert.Equal(t, "newrelic-cli/test", env.Ref)
+	assert.Equal(t, "api_key", env.Key)
+	assert.NotEmpty(t, env.Backend, "post-keyring failure must still populate backend")
+	assert.False(t, env.Written)
+	assert.Contains(t, env.Error, "--overwrite")
+
+	// SilenceErrors must have prevented cobra from re-printing the error.
+	assert.Empty(t, stderr.String(), "stderr must be empty on --json failure (SilenceErrors)")
+
+	// §1.12: no secret leakage on the failure path either.
+	combined := stdout.String() + stderr.String()
+	assert.NotContains(t, combined, secretSentinel)
+	assert.NotContains(t, combined, "NRAK-other-value")
+}
+
+func TestSetCredential_JSONFailure_InvalidKey_PreKeyring(t *testing.T) {
+	testutil.Setup(t)
+	stdout, stderr, err := runSetCredentialViaRoot(t,
+		secretSentinel+"\n",
+		"--ref", "newrelic-cli/test", "--key", "bogus_key", "--stdin", "--json")
+	require.Error(t, err)
+
+	env := parseEnvelope(t, stdout)
+	assert.Empty(t, env.Backend, "pre-keyring failure must leave backend empty")
+	assert.False(t, env.Written)
+	assert.Contains(t, env.Error, "unsupported --key")
+	assert.Contains(t, env.Error, "api_key")
+
+	assert.Empty(t, stderr.String())
+	assert.NotContains(t, stdout.String()+stderr.String(), secretSentinel)
+}
+
+func TestSetCredential_JSONFailure_MissingRefNoConfig_PreKeyring(t *testing.T) {
+	testutil.Setup(t)
+	stdout, stderr, err := runSetCredentialViaRoot(t,
+		secretSentinel+"\n",
+		"--key", "api_key", "--stdin", "--json")
+	require.Error(t, err)
+
+	env := parseEnvelope(t, stdout)
+	assert.Empty(t, env.Ref)
+	assert.Empty(t, env.Backend)
+	assert.False(t, env.Written)
+	assert.Contains(t, env.Error, "no config.yml found")
+	assert.Contains(t, env.Error, "newrelic-cli/default")
+
+	assert.Empty(t, stderr.String())
+}
+
+func TestSetCredential_JSONFailure_BothStdinAndEnv_PreKeyring(t *testing.T) {
+	testutil.Setup(t)
+	t.Setenv("NRQ_TEST_VAR", "ignored-value")
+	stdout, _, err := runSetCredentialViaRoot(t,
+		secretSentinel+"\n",
+		"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin", "--from-env", "NRQ_TEST_VAR", "--json")
+	require.Error(t, err)
+
+	env := parseEnvelope(t, stdout)
+	assert.False(t, env.Written)
+	assert.Contains(t, env.Error, "exactly one")
+}
+
+// --- --ref strict defaulting tests ------------------------------------------
+
+func TestSetCredential_RefDefaulting_NoConfigOmittedFails(t *testing.T) {
+	testutil.Setup(t)
+	_, _, err := runSetCredentialViaRoot(t,
+		secretSentinel+"\n",
+		"--key", "api_key", "--stdin")
+	require.Error(t, err)
+	combined := err.Error()
+	assert.Contains(t, combined, "--ref")
+	assert.Contains(t, combined, "newrelic-cli/default")
+}
+
+func TestSetCredential_RefDefaulting_ConfigExistsUsesActive(t *testing.T) {
+	testutil.Setup(t)
+	// Write a config.yml with a non-default credential_ref.
+	c := &config.Config{CredentialRef: "newrelic-cli/custom"}
+	require.NoError(t, c.Save())
+
+	_, _, err := runSetCredentialViaRoot(t,
+		secretSentinel+"\n",
+		"--key", "api_key", "--stdin")
+	require.NoError(t, err)
+
+	// Verify the secret landed in the active ref's bundle.
+	st, err := keychain.OpenNoMigrate()
+	require.NoError(t, err)
+	defer func() { _ = st.Close() }()
+	assert.Equal(t, "newrelic-cli/custom", st.Ref())
+}
+
+func TestSetCredential_RefDefaulting_ExplicitWins(t *testing.T) {
+	testutil.Setup(t)
+	c := &config.Config{CredentialRef: "newrelic-cli/from-config"}
+	require.NoError(t, c.Save())
+
+	_, _, err := runSetCredentialViaRoot(t,
+		secretSentinel+"\n",
+		"--ref", "newrelic-cli/explicit", "--key", "api_key", "--stdin")
+	require.NoError(t, err)
+
+	// The explicit --ref should win over the config's credential_ref.
+	// Probe the explicit bundle directly via OpenRef.
+	st, err := keychain.OpenRef("newrelic-cli/explicit")
+	require.NoError(t, err)
+	defer func() { _ = st.Close() }()
+	assert.True(t, st.HasAPIKey(), "explicit --ref bundle must have received the key")
+}
+
+// --- §1.12 secret-leak audit across every failure path ---------------------
+
+func TestSetCredential_NeverEmitsSecret_AcrossAllPaths(t *testing.T) {
+	// Exhaustive: every failure case + the success case. The sentinel
+	// must not appear in stdout or stderr regardless of --json setting.
+	cases := []struct {
+		name string
+		args []string
+		seed func(t *testing.T)
+	}{
+		{
+			name: "invalid_key",
+			args: []string{"--ref", "newrelic-cli/test", "--key", "bogus", "--stdin"},
+		},
+		{
+			name: "invalid_key_json",
+			args: []string{"--ref", "newrelic-cli/test", "--key", "bogus", "--stdin", "--json"},
+		},
+		{
+			name: "missing_ref_no_config",
+			args: []string{"--key", "api_key", "--stdin"},
+		},
+		{
+			name: "missing_ref_no_config_json",
+			args: []string{"--key", "api_key", "--stdin", "--json"},
+		},
+		{
+			name: "both_stdin_and_env",
+			args: []string{"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin", "--from-env", "FOO"},
+			seed: func(t *testing.T) { t.Setenv("FOO", "ignored") },
+		},
+		{
+			name: "existing_key",
+			args: []string{"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin"},
+			seed: func(t *testing.T) {
+				// Pre-seed via OpenRef so the next set-credential fails no-clobber.
+				st, err := keychain.OpenRef("newrelic-cli/test")
+				require.NoError(t, err)
+				require.NoError(t, st.SetAPIKey("NRAK-existing-12345"))
+				require.NoError(t, st.Close())
+			},
+		},
+		{
+			name: "existing_key_json",
+			args: []string{"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin", "--json"},
+			seed: func(t *testing.T) {
+				st, err := keychain.OpenRef("newrelic-cli/test")
+				require.NoError(t, err)
+				require.NoError(t, st.SetAPIKey("NRAK-existing-12345"))
+				require.NoError(t, st.Close())
+			},
+		},
+		{
+			name: "success_human",
+			args: []string{"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin"},
+		},
+		{
+			name: "success_json",
+			args: []string{"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin", "--json"},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.Setup(t)
+			if tc.seed != nil {
+				tc.seed(t)
+			}
+			stdout, stderr, _ := runSetCredentialViaRoot(t, secretSentinel+"\n", tc.args...)
+			combined := stdout.String() + stderr.String()
+			assert.NotContains(t, combined, secretSentinel,
+				"case %q: secret leaked to stdout or stderr", tc.name)
+		})
+	}
+}
+
+// silence the unused import warning if FOO env var is unused in some branches
+var _ = os.Setenv

--- a/internal/cmd/configcmd/set_credential_test.go
+++ b/internal/cmd/configcmd/set_credential_test.go
@@ -169,11 +169,13 @@ func TestSetCredential_RefDefaulting_ConfigExistsUsesActive(t *testing.T) {
 		"--key", "api_key", "--stdin")
 	require.NoError(t, err)
 
-	// Verify the secret landed in the active ref's bundle.
+	// Verify the secret landed in the active ref's bundle — not just that
+	// the right ref was opened, but that the key was actually written.
 	st, err := keychain.OpenNoMigrate()
 	require.NoError(t, err)
 	defer func() { _ = st.Close() }()
 	assert.Equal(t, "newrelic-cli/custom", st.Ref())
+	assert.True(t, st.HasAPIKey(), "active ref's bundle must have received the key")
 }
 
 func TestSetCredential_RefDefaulting_ExplicitWins(t *testing.T) {

--- a/internal/cmd/configcmd/set_credential_test.go
+++ b/internal/cmd/configcmd/set_credential_test.go
@@ -3,7 +3,6 @@ package configcmd
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
@@ -270,5 +269,30 @@ func TestSetCredential_NeverEmitsSecret_AcrossAllPaths(t *testing.T) {
 	}
 }
 
-// silence the unused import warning if FOO env var is unused in some branches
-var _ = os.Setenv
+// --- Root-flag position invariance (Codex Major fix) ----------------------
+
+// TestSetCredential_RootJSONBeforeSubcommand_AlsoEmitsEnvelope guards the
+// fix for the order-dependence bug: `nrq -o json set-credential ...` (root
+// flag before the subcommand) must emit the envelope and silence stderr,
+// same as `nrq set-credential --json ...`. Without the o.Output == "json"
+// normalization in the RunE wrapper, the two forms diverge silently.
+func TestSetCredential_RootJSONBeforeSubcommand_AlsoEmitsEnvelope(t *testing.T) {
+	testutil.Setup(t)
+	rootCmd, opts := root.NewRootCmd()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	opts.Stdout, opts.Stderr = stdout, stderr
+	opts.Stdin = strings.NewReader(secretSentinel + "\n")
+	root.RegisterAll(rootCmd, opts, Register)
+	// Root --output BEFORE the subcommand.
+	rootCmd.SetArgs([]string{"-o", "json", "set-credential",
+		"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin"})
+	require.NoError(t, rootCmd.Execute())
+
+	env := parseEnvelope(t, stdout)
+	assert.True(t, env.Written)
+	assert.Equal(t, "newrelic-cli/test", env.Ref)
+	assert.NotEmpty(t, env.Backend)
+	assert.Empty(t, stderr.String(), "root --output json must trigger SilenceErrors path too")
+	assert.NotContains(t, stdout.String()+stderr.String(), secretSentinel)
+}

--- a/internal/cmd/configcmd/set_credential_test.go
+++ b/internal/cmd/configcmd/set_credential_test.go
@@ -134,7 +134,7 @@ func TestSetCredential_JSONFailure_MissingRefNoConfig_PreKeyring(t *testing.T) {
 func TestSetCredential_JSONFailure_BothStdinAndEnv_PreKeyring(t *testing.T) {
 	testutil.Setup(t)
 	t.Setenv("NRQ_TEST_VAR", "ignored-value")
-	stdout, _, err := runSetCredentialViaRoot(t,
+	stdout, stderr, err := runSetCredentialViaRoot(t,
 		secretSentinel+"\n",
 		"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin", "--from-env", "NRQ_TEST_VAR", "--json")
 	require.Error(t, err)
@@ -142,6 +142,7 @@ func TestSetCredential_JSONFailure_BothStdinAndEnv_PreKeyring(t *testing.T) {
 	env := parseEnvelope(t, stdout)
 	assert.False(t, env.Written)
 	assert.Contains(t, env.Error, "exactly one")
+	assert.Empty(t, stderr.String(), "SilenceErrors must keep stderr empty on --json pre-keyring failure")
 }
 
 // --- --ref strict defaulting tests ------------------------------------------
@@ -270,6 +271,32 @@ func TestSetCredential_NeverEmitsSecret_AcrossAllPaths(t *testing.T) {
 }
 
 // --- Root-flag position invariance (Codex Major fix) ----------------------
+
+// TestSetCredential_RootDeprecatedJSONBeforeSubcommand_AlsoEmitsEnvelope
+// covers the deprecated root `--json` boolean variant of the same fix —
+// root.go:146 registers it as a deprecated alias, and `nrq --json
+// set-credential ...` must trigger the envelope path too.
+func TestSetCredential_RootDeprecatedJSONBeforeSubcommand_AlsoEmitsEnvelope(t *testing.T) {
+	testutil.Setup(t)
+	rootCmd, opts := root.NewRootCmd()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	opts.Stdout, opts.Stderr = stdout, stderr
+	opts.Stdin = strings.NewReader(secretSentinel + "\n")
+	root.RegisterAll(rootCmd, opts, Register)
+	// Deprecated root --json BEFORE the subcommand.
+	rootCmd.SetArgs([]string{"--json", "set-credential",
+		"--ref", "newrelic-cli/test", "--key", "api_key", "--stdin"})
+	require.NoError(t, rootCmd.Execute())
+
+	env := parseEnvelope(t, stdout)
+	assert.True(t, env.Written)
+	assert.NotEmpty(t, env.Backend)
+	// Stderr may contain cobra's deprecation notice for --json — that's a
+	// general nrq warning surface, not a set-credential failure. The §1.12
+	// invariant only forbids the secret value itself.
+	assert.NotContains(t, stdout.String()+stderr.String(), secretSentinel)
+}
 
 // TestSetCredential_RootJSONBeforeSubcommand_AlsoEmitsEnvelope guards the
 // fix for the order-dependence bug: `nrq -o json set-credential ...` (root

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -93,9 +93,11 @@ users, and other New Relic resources.
 First-time setup (API key in the OS keyring — never plaintext, never in config.yml):
   nrq init
 
-Non-interactive credential ingress:
-  op read "op://vault/New Relic/api key" | nrq set-credential --key api_key --stdin
-  nrq set-credential --key api_key --from-env NEWRELIC_API_KEY
+Non-interactive credential ingress (--ref is required when no config.yml
+exists — §1.5.2; once 'nrq init' has run, --ref defaults to the active
+config's credential_ref):
+  op read "op://vault/New Relic/api key" | nrq set-credential --ref newrelic-cli/default --key api_key --stdin
+  nrq set-credential --ref newrelic-cli/default --key api_key --from-env NEWRELIC_API_KEY
 
 Set the non-secret account ID / region (written to config.yml):
   nrq config set --account-id <id> --region US

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,9 +172,12 @@ func hasUserConfigInDir(newDir string) (bool, error) {
 
 	reloc, relErr := detectRelocation(newDir)
 	if relErr != nil {
-		if errors.Is(relErr, ErrRelocationConflict) {
-			return false, relErr
-		}
+		// Propagate any error — ErrRelocationConflict, malformed-old,
+		// permission errors, etc. Silently swallowing non-conflict errors
+		// would misreport "no config exists" on a box where config does
+		// exist but is temporarily unreadable, causing set-credential to
+		// incorrectly demand --ref.
+		return false, relErr
 	}
 	if reloc.Kind == relocOldOnly {
 		oldYML := filepath.Join(reloc.OldPath, configFileName)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,6 +155,14 @@ func HasUserConfig() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	return hasUserConfigInDir(newDir)
+}
+
+// hasUserConfigInDir is the testable seam — production AND tests both call
+// this. Splitting the dir resolution from the file probe lets the relocation
+// suite exercise old-only / malformed paths without re-implementing them
+// (mirrors the loadFromNewDir / Load split in this file).
+func hasUserConfigInDir(newDir string) (bool, error) {
 	newYML := filepath.Join(newDir, configFileName)
 	if _, found, err := readConfigYML(newYML); err != nil {
 		return false, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,6 +144,41 @@ func Load() (*Config, error) {
 	return loadFromNewDir(newDir)
 }
 
+// HasUserConfig reports whether a config.yml exists at the canonical path
+// or a relocation-fallback path. Mirrors loadFromNewDir's file-presence
+// semantics (including relocOldOnly). Callers should treat malformed
+// configs as errors, not silently as "no config" — set-credential uses
+// this to decide whether --ref is required per §1.5.2 (--ref defaults to
+// the active config's credential_ref only if a config file already exists).
+func HasUserConfig() (bool, error) {
+	newDir, err := Dir()
+	if err != nil {
+		return false, err
+	}
+	newYML := filepath.Join(newDir, configFileName)
+	if _, found, err := readConfigYML(newYML); err != nil {
+		return false, err
+	} else if found {
+		return true, nil
+	}
+
+	reloc, relErr := detectRelocation(newDir)
+	if relErr != nil {
+		if errors.Is(relErr, ErrRelocationConflict) {
+			return false, relErr
+		}
+	}
+	if reloc.Kind == relocOldOnly {
+		oldYML := filepath.Join(reloc.OldPath, configFileName)
+		if _, found, err := readConfigYML(oldYML); err != nil {
+			return false, err
+		} else if found {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // loadFromNewDir is the testable seam — production AND tests both call this.
 // Splitting it out avoids the "test helper as parallel implementation" trap
 // (slck MON-5372 Codex r1 lesson): production can never silently regress

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -119,3 +119,34 @@ func TestDir_StatedirContract(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "42", got.AccountID)
 }
+
+func TestHasUserConfig_Absent(t *testing.T) {
+	testutil.Setup(t)
+	has, err := config.HasUserConfig()
+	require.NoError(t, err)
+	assert.False(t, has, "absent config.yml must return false")
+}
+
+func TestHasUserConfig_Present(t *testing.T) {
+	testutil.Setup(t)
+	c := &config.Config{CredentialRef: "newrelic-cli/test"}
+	require.NoError(t, c.Save())
+
+	has, err := config.HasUserConfig()
+	require.NoError(t, err)
+	assert.True(t, has, "saved config.yml must register as present")
+}
+
+func TestHasUserConfig_MalformedSurfacesError(t *testing.T) {
+	testutil.Setup(t)
+	cfgPath, err := config.Path()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o700))
+	// Write deliberately bad YAML.
+	require.NoError(t, os.WriteFile(cfgPath, []byte("not: : valid: yaml\n"), 0o600))
+
+	has, err := config.HasUserConfig()
+	require.Error(t, err, "malformed config.yml must surface as an error, not silently as absent")
+	assert.False(t, has)
+	assert.NotContains(t, strings.ToLower(err.Error()), "secret", "error path must not echo any secret content")
+}

--- a/internal/config/relocate_test.go
+++ b/internal/config/relocate_test.go
@@ -185,3 +185,24 @@ func TestLoadForRuntime_DivergentMalformedCanonical_HardFail(t *testing.T) {
 // resetOnce returns a fresh sync.Once so warn-once side effects don't bleed
 // between tests in this file.
 func resetOnce() sync.Once { return sync.Once{} }
+
+// HasUserConfig must register a relocOldOnly config as present — otherwise
+// set-credential would falsely demand --ref on a box where the user has a
+// pre-relocation config.yml under the old hand-rolled path. Mirrors row 2
+// (TestRelocate_OldOnly_CopyNeeded) but for the §1.5.2 ref-defaulting path.
+func TestHasUserConfig_RelocOldOnly_RegistersAsPresent(t *testing.T) {
+	old, new := setupRelocPair(t)
+	writeYAML(t, filepath.Join(old, configFileName), "credential_ref: newrelic-cli/legacy\n")
+
+	has, err := hasUserConfigInDir(new)
+	require.NoError(t, err)
+	assert.True(t, has, "old-only config.yml must register as present")
+}
+
+// And the negative case: neither side has a config.yml.
+func TestHasUserConfig_RelocNeither_RegistersAsAbsent(t *testing.T) {
+	_, new := setupRelocPair(t)
+	has, err := hasUserConfigInDir(new)
+	require.NoError(t, err)
+	assert.False(t, has)
+}

--- a/internal/config/relocate_test.go
+++ b/internal/config/relocate_test.go
@@ -206,3 +206,21 @@ func TestHasUserConfig_RelocNeither_RegistersAsAbsent(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, has)
 }
+
+// HasUserConfig under ErrRelocationConflict: a divergent canonical/old pair
+// means there IS a user config (in fact two), but the divergence must be
+// surfaced rather than silently picked. set-credential callers should fail
+// loud rather than write to the wrong bundle.
+func TestHasUserConfig_RelocBothDivergent_SurfacesConflict(t *testing.T) {
+	old, new := setupRelocPair(t)
+	writeYAML(t, filepath.Join(old, configFileName), "credential_ref: newrelic-cli/old\n")
+	writeYAML(t, filepath.Join(new, configFileName), "credential_ref: newrelic-cli/new\n")
+
+	has, err := hasUserConfigInDir(new)
+	// Canonical IS present (we wrote new/), so the canonical readConfigYML
+	// branch fires first and returns true. ErrRelocationConflict surfaces
+	// through Load — HasUserConfig is "is there a file?", not "is the
+	// state coherent?". Verify the canonical-present case wins.
+	require.NoError(t, err)
+	assert.True(t, has, "canonical readable present → reported present regardless of conflict")
+}

--- a/internal/config/relocate_test.go
+++ b/internal/config/relocate_test.go
@@ -207,20 +207,20 @@ func TestHasUserConfig_RelocNeither_RegistersAsAbsent(t *testing.T) {
 	assert.False(t, has)
 }
 
-// HasUserConfig under ErrRelocationConflict: a divergent canonical/old pair
-// means there IS a user config (in fact two), but the divergence must be
-// surfaced rather than silently picked. set-credential callers should fail
-// loud rather than write to the wrong bundle.
-func TestHasUserConfig_RelocBothDivergent_SurfacesConflict(t *testing.T) {
+// HasUserConfig answers "does a config.yml file exist?" — not "is the state
+// coherent?". When both canonical and old config.yml are present (the
+// bothDivergent row that detectRelocation would flag as
+// ErrRelocationConflict), the canonical readConfigYML check fires first and
+// short-circuits before detectRelocation is reached. The conflict is
+// surfaced through Load / LoadForRuntime at config-read time; not here.
+// This test pins the short-circuit so a future refactor that reorders the
+// probes doesn't accidentally route bothDivergent into the error path.
+func TestHasUserConfig_BothPresent_CanonicalShortCircuits(t *testing.T) {
 	old, new := setupRelocPair(t)
 	writeYAML(t, filepath.Join(old, configFileName), "credential_ref: newrelic-cli/old\n")
 	writeYAML(t, filepath.Join(new, configFileName), "credential_ref: newrelic-cli/new\n")
 
 	has, err := hasUserConfigInDir(new)
-	// Canonical IS present (we wrote new/), so the canonical readConfigYML
-	// branch fires first and returns true. ErrRelocationConflict surfaces
-	// through Load — HasUserConfig is "is there a file?", not "is the
-	// state coherent?". Verify the canonical-present case wins.
 	require.NoError(t, err)
-	assert.True(t, has, "canonical readable present → reported present regardless of conflict")
+	assert.True(t, has, "canonical readable → reported present without invoking detectRelocation")
 }

--- a/internal/noleak/noleak_test.go
+++ b/internal/noleak/noleak_test.go
@@ -528,10 +528,11 @@ func TestConfigClear_All_MalformedConfig_StillScrubsFiles(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "legacy credentials must be scrubbed")
 }
 
-// §1.10 fresh-install automation primitive: on a box with NO config.yml,
-// `nrq set-credential --key api_key --stdin` (no --ref) must work, falling
-// back to the default ref — not error demanding --ref.
-func TestSetCredential_FreshInstall_NoRefNoConfig(t *testing.T) {
+// §1.5.2 strict: on a box with NO config.yml, `nrq set-credential
+// --key api_key --stdin` (no --ref) must FAIL with a clear hint naming the
+// canonical ref. This replaces the prior §1.10 fresh-install carve-out
+// per the family-wide alignment in cli-common PR #28.
+func TestSetCredential_FreshInstall_NoRefNoConfig_NowRequiresRef(t *testing.T) {
 	testutil.Setup(t)
 	_, statErr := os.Stat(mustConfigPath(t))
 	require.True(t, os.IsNotExist(statErr), "precondition: no config.yml")
@@ -542,7 +543,29 @@ func TestSetCredential_FreshInstall_NoRefNoConfig(t *testing.T) {
 	opts.Stdin = strings.NewReader(sentinel + "\n")
 	root.RegisterAll(rootCmd, opts, configcmd.Register)
 	rootCmd.SetArgs([]string{"set-credential", "--key", "api_key", "--stdin"})
-	require.NoError(t, rootCmd.Execute(), "fresh-install set-credential must not require --ref")
+	err := rootCmd.Execute()
+	require.Error(t, err, "§1.5.2 requires --ref when no config.yml exists")
+	combined := err.Error() + o.String() + e.String()
+	assert.Contains(t, combined, "--ref")
+	assert.Contains(t, combined, "newrelic-cli/default")
+	assert.NotContains(t, combined, sentinel, "§1.12: no secret leakage on the failure path either")
+}
+
+// Sibling proving the migration path: pass --ref explicitly and the same
+// fresh-install command succeeds. This is the one-flag fix installers need
+// to adopt.
+func TestSetCredential_FreshInstall_WithRefSucceeds(t *testing.T) {
+	testutil.Setup(t)
+	_, statErr := os.Stat(mustConfigPath(t))
+	require.True(t, os.IsNotExist(statErr), "precondition: no config.yml")
+
+	rootCmd, opts := root.NewRootCmd()
+	var o, e bytes.Buffer
+	opts.Stdout, opts.Stderr = &o, &e
+	opts.Stdin = strings.NewReader(sentinel + "\n")
+	root.RegisterAll(rootCmd, opts, configcmd.Register)
+	rootCmd.SetArgs([]string{"set-credential", "--ref", "newrelic-cli/default", "--key", "api_key", "--stdin"})
+	require.NoError(t, rootCmd.Execute())
 	assert.NotContains(t, o.String()+e.String(), sentinel)
 
 	st, err := keychain.OpenNoMigrate()


### PR DESCRIPTION
## Summary
Two coupled changes against `nrq set-credential`:

- **`--json` envelope** — emits `{ref,key,backend,written,error?}` on stdout per §1.5.2 / §1.8. Envelope shape splits by phase: pre-keyring failures leave `backend` empty; post-keyring failures populate it from `store.Backend()`. `cmd.SilenceErrors=true` under `--json` keeps stderr empty so the envelope is the only failure signal.
- **`--ref` strict** — per §1.5.2 line 203, when no `config.yml` exists AND `--ref` is omitted, fail with a hint naming `newrelic-cli/default`. New `config.HasUserConfig()` mirrors `loadFromNewDir`'s file-presence semantics (canonical → relocOldOnly → malformed surfaces as error). The §1.10 fresh-install carve-out at `noleak_test.go:531` is flipped; help text updated to show the new shape.

## Why
Family-wide alignment with the cli-common standards landed in PR open-cli-collective/cli-common#28. The set-credential surface is the reference shape that atlassian-cli #389 (jtk+cfl) and salesforce-cli #43 (new sfdc command) will follow.

## Breaking change
Fresh-install installers using `op read | nrq set-credential --key api_key --stdin` (no `--ref`) now fail with a clear hint. The one-flag migration is `--ref newrelic-cli/default`. PR description for the user-facing changelog can mirror this.

## Test plan
- [x] `make verify` (tidy + lint + test) — green: 51 tests across configcmd, noleak, keychain, output, validate, version, view.
- [x] `make build` — `bin/nrq` produced.
- [x] New tests in `internal/config/config_test.go`:
  - `TestHasUserConfig_Absent` / `_Present` / `_MalformedSurfacesError`.
- [x] New tests in `internal/cmd/configcmd/set_credential_test.go`:
  - JSON success / failure variants (existing key, invalid key, missing ref, both stdin and env).
  - `--ref` strict defaulting (no-config-fails, config-uses-active, explicit-wins).
  - Exhaustive §1.12 leak audit across every failure path (`TestSetCredential_NeverEmitsSecret_AcrossAllPaths`).
- [x] Flipped `noleak_test.go:531` to `TestSetCredential_FreshInstall_NoRefNoConfig_NowRequiresRef`; new sibling `TestSetCredential_FreshInstall_WithRefSucceeds`.
- [x] Help text updated in `internal/cmd/root/root.go:96` and `internal/cmd/configcmd/config.go:67`.

## Out of scope
- Removing `-o json` from resource reads (separate ticket: open-cli-collective/newrelic-cli#108).
- `nrq init` ingress changes (different command).
- `nrq config show --json` (separate surface).

Closes #107