### PR TITLE
feat(api): surface NerdGraph error path + extensions in GraphQL errors

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -171,7 +171,7 @@ func (c *Client) NerdGraphQuery(query string, variables map[string]interface{}) 
 	}
 
 	if len(resp.Errors) > 0 {
-		return nil, &GraphQLError{Message: resp.Errors[0].Message}
+		return nil, &GraphQLError{Message: resp.Errors[0].Message, Errors: resp.Errors}
 	}
 
 	return resp.Data, nil

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // Common errors
@@ -52,14 +54,43 @@ func IsUnauthorized(err error) bool {
 	return false
 }
 
-// GraphQLError represents an error from a NerdGraph query
+// GraphQLError represents an error from a NerdGraph query. Message is the
+// first error's message (kept for back-compat); Errors carries the full set
+// with their `path` / `extensions`, which often hold the actionable detail —
+// e.g. which field failed validation on an alert-condition mutation.
 type GraphQLError struct {
 	Message string
+	Errors  []NerdGraphError
 }
 
-// Error implements the error interface
+// Error implements the error interface. It leads with the first message, then
+// appends the structured detail NerdGraph returns (each error's path +
+// extensions, and any additional errors) so callers see *why* a query was
+// rejected instead of a bare "Validation Error".
 func (e *GraphQLError) Error() string {
-	return fmt.Sprintf("GraphQL error: %s", e.Message)
+	msg := fmt.Sprintf("GraphQL error: %s", e.Message)
+	var details []string
+	for _, ge := range e.Errors {
+		var parts []string
+		if len(e.Errors) > 1 {
+			parts = append(parts, ge.Message)
+		}
+		if len(ge.Path) > 0 {
+			parts = append(parts, fmt.Sprintf("path=%v", ge.Path))
+		}
+		if len(ge.Extensions) > 0 {
+			if j, err := json.Marshal(ge.Extensions); err == nil && string(j) != "{}" {
+				parts = append(parts, fmt.Sprintf("extensions=%s", j))
+			}
+		}
+		if len(parts) > 0 {
+			details = append(details, strings.Join(parts, " "))
+		}
+	}
+	if len(details) > 0 {
+		msg += "\n  " + strings.Join(details, "\n  ")
+	}
+	return msg
 }
 
 // ResponseError represents an error parsing the response

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -112,6 +112,38 @@ func TestGraphQLError_Error(t *testing.T) {
 	assert.Equal(t, "GraphQL error: Field 'foo' not found", err.Error())
 }
 
+func TestGraphQLError_Error_SurfacesPathAndExtensions(t *testing.T) {
+	err := &GraphQLError{
+		Message: "Validation Error",
+		Errors: []NerdGraphError{
+			{
+				Message: "Validation Error",
+				Path:    []interface{}{"alertsNrqlConditionStaticCreate"},
+				Extensions: map[string]interface{}{
+					"errorClass": "BAD_USER_INPUT",
+				},
+			},
+		},
+	}
+	got := err.Error()
+	assert.Contains(t, got, "GraphQL error: Validation Error")
+	assert.Contains(t, got, "path=[alertsNrqlConditionStaticCreate]")
+	assert.Contains(t, got, `"errorClass":"BAD_USER_INPUT"`)
+}
+
+func TestGraphQLError_Error_ListsMultipleErrors(t *testing.T) {
+	err := &GraphQLError{
+		Message: "first problem",
+		Errors: []NerdGraphError{
+			{Message: "first problem"},
+			{Message: "second problem"},
+		},
+	}
+	got := err.Error()
+	assert.Contains(t, got, "GraphQL error: first problem")
+	assert.Contains(t, got, "second problem")
+}
+
 func TestResponseError_Error(t *testing.T) {
 	t.Run("with underlying error", func(t *testing.T) {
 		err := &ResponseError{

--- a/api/types.go
+++ b/api/types.go
@@ -373,7 +373,13 @@ type NerdGraphResponse struct {
 	Errors []NerdGraphError       `json:"errors,omitempty"`
 }
 
-// NerdGraphError represents a GraphQL error
+// NerdGraphError represents a GraphQL error. Beyond the human-readable
+// message, NerdGraph returns structured detail in `extensions` (e.g. the
+// specific validation failures for an alert-condition mutation) and points at
+// the offending field via `path` — both previously discarded at parse time.
 type NerdGraphError struct {
-	Message string `json:"message"`
+	Message    string                   `json:"message"`
+	Path       []interface{}            `json:"path,omitempty"`
+	Locations  []map[string]interface{} `json:"locations,omitempty"`
+	Extensions map[string]interface{}   `json:"extensions,omitempty"`
 }


### PR DESCRIPTION
## Summary

`nerdgraph query` collapsed every GraphQL error to `errors[0].message`, so a NerdGraph **"Validation Error"** surfaced with no clue *why* it failed. The actionable detail lives in each error's `extensions` (and `path`) — but `NerdGraphError` didn't even parse those fields, so they were discarded before formatting.

Concretely, an alert-condition mutation rejected for a specific field printed only:

```
Error: GraphQL error: Validation Error
```

With this change it prints:

```
Error: GraphQL error: Validation Error
  path=[alertsNrqlConditionStaticCreate] extensions={"code":"BAD_USER_INPUT","errorClass":"BAD_USER_INPUT","validationErrors":[{"name":"settings.aggregation_delay","reason":"Aggregation delay must be supplied when aggregation method is 'EVENT_FLOW'"}]}
```

### Changes
- `api/types.go` — parse `path`, `locations`, `extensions` on `NerdGraphError` (previously message-only).
- `api/errors.go` — `GraphQLError` carries the full `[]NerdGraphError`; `Error()` appends each error's `path` + `extensions` and lists any additional errors after the lead message.
- `api/client.go` — pass the full error slice through.

**Back-compat:** when there's no structured detail, output is unchanged (`GraphQL error: <message>`); the existing test still passes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's code style (`gofmt` clean, `go vet ./api/` clean)
- [x] I have added tests that prove my fix/feature works (message-only, path+extensions, multi-error)
- [x] All new and existing tests pass (`make test` green)
- [ ] Linting passes (`make lint`) — couldn't run locally: golangci-lint v2.8.0 panics under Go 1.25.5 (internal goanalysis crash, unrelated to this change); relying on CI's pinned toolchain
- [ ] I have updated documentation if needed (n/a)

## Related Issues

N/A — surfaced while diagnosing a New Relic alert push that failed with a bare "Validation Error".