### PR TITLE
fix(release): build linux with CGO via zig so releases stop failing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
           version: "~> v2"
           install-only: true
 
+      # zig is the C cross-compiler for the linux CGO builds (onepassword-sdk-go
+      # requires CGO on linux). darwin uses xcrun clang natively; linux/musl
+      # cross-compiles from this macOS runner via `zig cc`. See .goreleaser.yml.
+      - name: Install zig (linux CGO cross-compiler)
+        run: brew install zig
+
       - name: GoReleaser check
         run: goreleaser check
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,13 +36,49 @@ builds:
       - -X github.com/open-cli-collective/newrelic-cli/internal/version.Version={{.Version}}
       - -X github.com/open-cli-collective/newrelic-cli/internal/version.Commit={{.Commit}}
       - -X github.com/open-cli-collective/newrelic-cli/internal/version.BuildDate={{.Date}}
-  - id: nrq-unix-win
+  # linux must ALSO build with CGO: onepassword-sdk-go (transitive via
+  # cli-common) has no pure-Go path on linux — its client_builder_no_cgo.go
+  # (//go:build !cgo && (darwin || linux)) is a compile-error sentinel, so the
+  # old CGO-off linux build broke every release since v1.0.39. We cross-compile
+  # CGO from the macOS runner with zig (installed in release.yml), targeting
+  # musl so the binaries stay STATIC + portable — better than the dynamic-glibc
+  # concern the original CGO-off split was avoiding. Windows is unaffected: the
+  # SDK's client_builder_cgo.go builds under `cgo || windows`, so CGO-off
+  # windows still compiles — it keeps its own static CGO-off build below.
+  - id: nrq-linux
+    main: ./cmd/nrq
+    binary: nrq
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    overrides:
+      - goos: linux
+        goarch: amd64
+        env:
+          - CGO_ENABLED=1
+          - "CC=zig cc -target x86_64-linux-musl"
+          - "CXX=zig c++ -target x86_64-linux-musl"
+      - goos: linux
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
+          - "CC=zig cc -target aarch64-linux-musl"
+          - "CXX=zig c++ -target aarch64-linux-musl"
+    ldflags:
+      - -s -w
+      - -X github.com/open-cli-collective/newrelic-cli/internal/version.Version={{.Version}}
+      - -X github.com/open-cli-collective/newrelic-cli/internal/version.Commit={{.Commit}}
+      - -X github.com/open-cli-collective/newrelic-cli/internal/version.BuildDate={{.Date}}
+  - id: nrq-windows
     main: ./cmd/nrq
     binary: nrq
     env:
       - CGO_ENABLED=0
     goos:
-      - linux
       - windows
     goarch:
       - amd64
@@ -68,11 +104,11 @@ archives:
 # Linux packages (.deb and .rpm)
 nfpms:
   - id: nrq
-    # deb/rpm are linux-only: pull the static CGO-off build, never darwin.
-    # `ids` (the v2 build-id filter) — `builds` is deprecated and fails
-    # `goreleaser check`.
+    # deb/rpm are linux-only: pull the static linux build (now CGO+zig+musl),
+    # never darwin/windows. `ids` (the v2 build-id filter) — `builds` is
+    # deprecated and fails `goreleaser check`.
     ids:
-      - nrq-unix-win
+      - nrq-linux
     package_name: nrq
     vendor: Open CLI Collective
     homepage: https://github.com/open-cli-collective/newrelic-cli


### PR DESCRIPTION
## Summary

The Release workflow has **failed on every version since v1.0.39** (latest published release is v1.0.38; tags v1.0.39–v1.0.44 exist but never published), so merged work — including #111 — can't ship. Root cause:

```
onepassword-sdk-go .../client_builder_no_cgo.go:7:10:
  undefined: ERROR_WithDesktopAppIntegration_requires_CGO_To_Cross_Compile_See_README_CGO_Section
```

`onepassword-sdk-go` (transitive via `cli-common`) has **no pure-Go path on darwin/linux** — its `client_builder_no_cgo.go` (`//go:build !cgo && (darwin || linux)`) is a deliberate compile-error sentinel. `darwin` already builds with CGO; the **linux** build was `CGO_ENABLED=0`, so it hit the sentinel and aborted goreleaser. (Windows is unaffected — the SDK's `_cgo.go` builds under `cgo || windows`, so CGO-off windows still compiles.)

## Fix
Split the `nrq-unix-win` build into:
- **`nrq-linux`** — `CGO_ENABLED=1`, cross-compiled from the macOS runner with `zig cc -target {x86_64,aarch64}-linux-musl`. Targeting **musl yields static binaries** — *more* portable than the dynamic-glibc build the original CGO-off split was avoiding, so the INT-448 portability concern is satisfied, not regressed.
- **`nrq-windows`** — `CGO_ENABLED=0`, unchanged.

Plus: install `zig` on the release runner, and point `nfpms` (deb/rpm) at `nrq-linux`.

## Verification (local — release.yml only runs on tags, so no PR CI)
- `goreleaser check` ✓
- `goreleaser release --snapshot --clean` → **`release succeeded`** (this is the exact step that's been failing). Built darwin amd64/arm64 (xcrun CGO), linux amd64/arm64 (zig+musl CGO), windows amd64/arm64 (CGO-off); produced tar.gz/zip archives + linux deb/rpm.
- `file` on the linux binaries: `ELF 64-bit … statically linked` (amd64 + aarch64).

Once merged, the auto-release should finally publish (carrying #111 and everything since v1.0.38), and `brew upgrade nrq` will pick it up.