### PR TITLE
fix(ci): pre-publish gate uses config show --json (not removed --output json)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,9 @@ jobs:
           tmp=$(mktemp -d)
           mkdir -p "$tmp/xdg/newrelic-cli"
           printf 'credential_ref: newrelic-cli/default\n' > "$tmp/xdg/newrelic-cli/config.yml"
-          out=$(env -u NEWRELIC_CLI_KEYRING_BACKEND HOME="$tmp" XDG_CONFIG_HOME="$tmp/xdg" "$arm_bin" --output json config show)
+          # `config show --json` (the §2 diagnostics carve-out flag), not the
+          # global `--output json` — #110 restricted `--output` to table/plain.
+          out=$(env -u NEWRELIC_CLI_KEYRING_BACKEND HOME="$tmp" XDG_CONFIG_HOME="$tmp/xdg" "$arm_bin" config show --json)
           echo "$out"
           b=$(echo "$out" | jq -r '.backend'); s=$(echo "$out" | jq -r '.backend_source'); r=$(echo "$out" | jq -r '.credential_ref')
           [ "$b" = "keychain" ] && [ "$s" = "auto" ] && [ "$r" = "newrelic-cli/default" ] \


### PR DESCRIPTION
## Summary

Follow-on to #112. The CGO/zig build fix let `v1.0.45` get past the build for the first time since #110 merged — and it then failed the **Pre-publish gate** step:

```
Error: invalid output format "json": must be one of table, plain
```

The gate read the darwin binary's credstore state via `nrq --output json config show`, but **#110** restricted the global `--output` flag to `table`/`plain` and moved JSON to the dedicated **`config show --json`** diagnostics carve-out. The gate never saw this until a release got past the build.

## Fix
One line: `--output json config show` → `config show --json`. The `--json` envelope still carries `backend` / `backend_source` / `credential_ref`, so the `jq` parse is unchanged.

Verified against the actual v1.0.45 snapshot darwin binary: `config show --json` → `{backend: keychain, backend_source: auto, credential_ref: newrelic-cli/default}` — exactly what the gate asserts.

(YAML-only change; the build + gate logic are otherwise untouched.)