### PR TITLE
ci: build all release targets on PRs (catch goreleaser breaks before tag time)

### DIFF
--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -1,0 +1,51 @@
+name: Release build check
+
+# Build the release artifacts on PRs that touch build-affecting files, so a
+# change that breaks `goreleaser` (CGO/cross-compile, toolchain, build config)
+# is caught at review time instead of at tag time. Before this existed, the
+# release build only ran on `v*` tags (release.yml), so breakage accumulated
+# undetected across several versions (no published release v1.0.39–v1.0.44).
+#
+# Mirrors release.yml's build environment exactly (macos-15 + zig for the
+# linux CGO cross-compile) but stops at `goreleaser build` — no archives,
+# packages, signing, or publish.
+
+on:
+  pull_request:
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - ".goreleaser.yml"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-build-check.yml"
+
+jobs:
+  build:
+    # darwin builds with CGO (Keychain) and can't cross-compile from Linux, and
+    # linux builds CGO cross-compiled via zig — same as release.yml, so the
+    # check runs on macOS to exercise the real release matrix.
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          install-only: true
+
+      - name: Install zig (linux CGO cross-compiler)
+        run: brew install zig
+
+      - name: GoReleaser check
+        run: goreleaser check
+
+      - name: Build all release targets (no publish)
+        run: goreleaser build --snapshot --clean


### PR DESCRIPTION
## Problem

The release build — `goreleaser`, including the darwin/linux **CGO cross-compile** — only ran on `v*` tags in `release.yml`. It **never ran on PRs**. So a change that broke the release build wasn't caught at review time; it was caught (if at all) at release time, and breakage **accumulated silently**:

- No release was published between **v1.0.38 and v1.0.46**.
- The linux build had been broken for ~6 versions: it built `CGO_ENABLED=0`, but `onepassword-sdk-go` (transitive via `cli-common`) has no pure-Go path on linux — `client_builder_no_cgo.go` is a compile-error sentinel. Fixed in #112 (linux now builds CGO via `zig`).
- A separate pre-publish-gate break (#113) also rode along undetected.

`ci.yml` runs `lint` + `test` on every PR, but nothing exercises the **release build**. That's the gap that let the rot accumulate.

## Fix

Add a `pull_request` check that mirrors `release.yml`'s build environment and runs the real release build, minus publishing:

- `runs-on: macos-15` — darwin builds need macOS (CGO/Keychain, no cross-compile from linux); linux builds CGO cross-compile from the macOS runner via `zig`. Same matrix `release.yml` uses.
- Installs GoReleaser (`~> v2`) + `zig`, then runs `goreleaser check` and `goreleaser build --snapshot --clean`.
- Stops at `build` — no archives, packages (nfpms), signing, or publish. Just "does every target still compile and link."
- **Path-gated** to build-affecting files (`**.go`, `go.mod`, `go.sum`, `.goreleaser.yml`, `release.yml`, and this workflow) so it only spends a macOS runner when a change could actually break the build.

Had this existed, the #112 break would have failed the PR that introduced it instead of blocking releases for six versions.

## Validation

`goreleaser build --snapshot --clean` (the exact command this check runs) builds all six targets clean locally — darwin amd64/arm64, linux amd64/arm64 (CGO via zig), windows amd64/arm64.

## Follow-up (not in this PR)

The pre-publish gate (the #113 class — gate logic drifting from the CLI) still only runs at tag time. Extracting it to a script and running it here after the snapshot build would close that gap too; left out to keep this PR focused on the build.