### PR TITLE
fix(snap): build with go 1.26 + CGO so the snap stops failing

### DIFF
--- a/.github/workflows/snap-build-check.yml
+++ b/.github/workflows/snap-build-check.yml
@@ -1,0 +1,31 @@
+name: Snap build check
+
+# Build the snap on PRs that touch snap config or Go dependencies, so a change
+# that breaks the snap build is caught at review time. The snap was previously
+# built only on `v*` tags (the `snap` job in release.yml), so breakage went
+# unnoticed: the snap build was failing while the GitHub release / Homebrew /
+# other channels kept shipping.
+#
+# Gated narrowly (snapcraft.yaml + go.mod/go.sum) rather than on every **.go
+# change — the snap is a plain `go build` of the same code release-build-check
+# already compiles on code PRs, and a snapcraft/LXD build is slow. The breakage
+# vectors specific to the snap are its build config and the Go toolchain/deps.
+
+on:
+  pull_request:
+    paths:
+      - "snap/snapcraft.yaml"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/snap-build-check.yml"
+
+jobs:
+  snap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # `version: git` in snapcraft.yaml needs tags/history
+
+      - name: Build snap (no publish)
+        uses: snapcore/action-build@v1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,9 +44,21 @@ parts:
     plugin: go
     source: .
     build-snaps:
-      - go/1.24/stable
+      # Must be >= go.mod's `go` directive. If it's older, the build go
+      # auto-downloads the required toolchain, and the "go: downloading goX..."
+      # line poisons snapcraft's go-compiler-version parse (build fails before
+      # compiling). Bump in lockstep with go.mod.
+      - go/1.26/stable
+    build-packages:
+      # CGO toolchain: onepassword-sdk-go (transitive) has no pure-Go path on
+      # linux, so it cannot be built with CGO disabled.
+      - gcc
+      - libc6-dev
     build-environment:
-      - CGO_ENABLED: "0"
+      - CGO_ENABLED: "1"
+      # Never auto-download a toolchain (see build-snaps note); fail loudly with
+      # a clear "go.mod requires go >= X" instead if the channel falls behind.
+      - GOTOOLCHAIN: local
     override-build: |
       # Get version from git
       VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")


### PR DESCRIPTION
## Problem

The `snap` job (release.yml, runs only on `v*` tags) has been failing while the GitHub release, Homebrew, and other channels kept shipping — so nobody noticed. Two breaks, both inherited from changes that were never exercised on a PR:

1. **Go toolchain version.** `build-snaps: go/1.24/stable` is older than go.mod's `go 1.26`. So the build go auto-downloads the 1.26 toolchain, and the `go: downloading go1.26.0 (linux/amd64)` line poisons snapcraft's go-compiler-version parse:

   > Environment validation failed for part 'nrq': invalid go compiler version 'go: downloading go1.26.0 (linux/amd64)'.

2. **CGO.** The snap built `CGO_ENABLED=0`, but `onepassword-sdk-go` (transitive via `cli-common`) has **no pure-Go path on linux** — `client_builder_no_cgo.go` is a compile-error sentinel (only `cgo || windows` compiles). This is the same break the release linux build hit (fixed for goreleaser in #112 via `zig`); the snap was never updated to match, and #1 was failing first so it was masked.

## Fix

`snap/snapcraft.yaml`:

- `build-snaps: go/1.24/stable` → **`go/1.26/stable`** (matches go.mod; auto-tracks 1.26.x patch releases). `go/1.26/stable` is a real published channel.
- Add **`GOTOOLCHAIN: local`** — never auto-download a toolchain. If the channel ever falls behind go.mod again, the build fails loudly with `go.mod requires go >= X` instead of the confusing parse-poison above.
- **`CGO_ENABLED: 0` → `1`** + `build-packages: [gcc, libc6-dev]`. The snap links glibc dynamically against its `core22` base, so no static/musl handling is needed here (unlike the bare release tarballs).

## Plus: a PR check (the actual rot)

Both breaks landed because **the snap was only ever built at tag time**. Adds `snap-build-check.yml`: builds the snap (no publish) on PRs touching `snap/snapcraft.yaml` or `go.mod`/`go.sum`. Gated narrowly rather than on every `**.go` — the snap is a plain `go build` of the same code #114 already compiles on code PRs, and an LXD snap build is slow; the snap-specific breakage vectors are its build config and the Go toolchain/deps.

## Validation

I can't run `snapcraft` locally (needs LXD/Linux), so the snap-build-check in this PR is the validation — it builds the snap on this very PR with the fixed config. Watching that check go green is the proof.

Companion to #114 (release-build PR check for goreleaser).