### PR TITLE
fix: restore static linux release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,24 @@ jobs:
       - name: Run tests with race detection
         run: go test -race -coverprofile=coverage.out ./...
 
+      - name: Static release build guard
+        run: |
+          set -euo pipefail
+          for target in linux/amd64 linux/arm64 windows/amd64 windows/arm64; do
+            goos="${target%/*}"
+            goarch="${target#*/}"
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+              go build -o "$RUNNER_TEMP/nrq-$goos-$goarch" ./cmd/nrq
+          done
+
+          for goarch in amd64 arm64; do
+            deps=$(CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" go list -deps ./cmd/nrq)
+            if printf '%s\n' "$deps" | grep -E '^(github.com/byteness/keyring|github.com/1password/onepassword-sdk-go)(/|$)'; then
+              echo "static Linux nrq $goarch build graph must not include byteness/keyring or onepassword-sdk-go"
+              exit 1
+            fi
+          done
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/release-build-check.yml
+++ b/.github/workflows/release-build-check.yml
@@ -6,9 +6,8 @@ name: Release build check
 # release build only ran on `v*` tags (release.yml), so breakage accumulated
 # undetected across several versions (no published release v1.0.39–v1.0.44).
 #
-# Mirrors release.yml's build environment exactly (macos-15 + zig for the
-# linux CGO cross-compile) but stops at `goreleaser build` — no archives,
-# packages, signing, or publish.
+# Mirrors release.yml's build environment exactly (macos-15 for darwin CGO)
+# but stops at `goreleaser build` — no archives, packages, signing, or publish.
 
 on:
   pull_request:
@@ -22,9 +21,8 @@ on:
 
 jobs:
   build:
-    # darwin builds with CGO (Keychain) and can't cross-compile from Linux, and
-    # linux builds CGO cross-compiled via zig — same as release.yml, so the
-    # check runs on macOS to exercise the real release matrix.
+    # darwin builds with CGO (Keychain) and can't cross-compile from Linux, so
+    # the check runs on macOS to exercise the real release matrix.
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -41,11 +39,46 @@ jobs:
           version: "~> v2"
           install-only: true
 
-      - name: Install zig (linux CGO cross-compiler)
-        run: brew install zig
-
       - name: GoReleaser check
         run: goreleaser check
 
+      - name: Static release build guard
+        run: |
+          set -euo pipefail
+          for target in linux/amd64 linux/arm64 windows/amd64 windows/arm64; do
+            goos="${target%/*}"
+            goarch="${target#*/}"
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+              go build -o "$RUNNER_TEMP/nrq-$goos-$goarch" ./cmd/nrq
+          done
+
+          for goarch in amd64 arm64; do
+            deps=$(CGO_ENABLED=0 GOOS=linux GOARCH="$goarch" go list -deps ./cmd/nrq)
+            if printf '%s\n' "$deps" | grep -E '^(github.com/byteness/keyring|github.com/1password/onepassword-sdk-go)(/|$)'; then
+              echo "static Linux nrq $goarch build graph must not include byteness/keyring or onepassword-sdk-go"
+              exit 1
+            fi
+          done
+
       - name: Build all release targets (no publish)
         run: goreleaser build --snapshot --clean
+
+      - name: Verify static Linux release artifacts
+        run: |
+          set -euo pipefail
+          art=dist/artifacts.json
+          for goarch in amd64 arm64; do
+            bin=$(jq -r --arg goarch "$goarch" '.[] | select(.type=="Binary" and .goos=="linux" and .goarch==$goarch) | .path' "$art")
+            [ -n "$bin" ] || { echo "missing linux/$goarch binary in artifacts.json"; exit 1; }
+            case "$bin" in
+              dist/nrq-unix-win_linux_*) ;;
+              *) echo "linux/$goarch binary came from unexpected build id: $bin"; exit 1 ;;
+            esac
+            file "$bin" | grep -q 'statically linked' \
+              || { echo "linux/$goarch release binary is not statically linked"; file "$bin"; exit 1; }
+          done
+
+          for goarch in amd64 arm64; do
+            count=$(jq --arg goarch "$goarch" '[.[] | select(.type=="Binary" and .goos=="linux" and .goarch==$goarch)] | length' "$art")
+            [ "$count" = 1 ] || { echo "expected exactly one linux/$goarch binary, found $count"; exit 1; }
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,6 @@ jobs:
           version: "~> v2"
           install-only: true
 
-      # zig is the C cross-compiler for the linux CGO builds (onepassword-sdk-go
-      # requires CGO on linux). darwin uses xcrun clang natively; linux/musl
-      # cross-compiles from this macOS runner via `zig cc`. See .goreleaser.yml.
-      - name: Install zig (linux CGO cross-compiler)
-        run: brew install zig
-
       - name: GoReleaser check
         run: goreleaser check
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,49 +36,13 @@ builds:
       - -X github.com/open-cli-collective/newrelic-cli/internal/version.Version={{.Version}}
       - -X github.com/open-cli-collective/newrelic-cli/internal/version.Commit={{.Commit}}
       - -X github.com/open-cli-collective/newrelic-cli/internal/version.BuildDate={{.Date}}
-  # linux must ALSO build with CGO: onepassword-sdk-go (transitive via
-  # cli-common) has no pure-Go path on linux — its client_builder_no_cgo.go
-  # (//go:build !cgo && (darwin || linux)) is a compile-error sentinel, so the
-  # old CGO-off linux build broke every release since v1.0.39. We cross-compile
-  # CGO from the macOS runner with zig (installed in release.yml), targeting
-  # musl so the binaries stay STATIC + portable — better than the dynamic-glibc
-  # concern the original CGO-off split was avoiding. Windows is unaffected: the
-  # SDK's client_builder_cgo.go builds under `cgo || windows`, so CGO-off
-  # windows still compiles — it keeps its own static CGO-off build below.
-  - id: nrq-linux
-    main: ./cmd/nrq
-    binary: nrq
-    env:
-      - CGO_ENABLED=1
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
-    overrides:
-      - goos: linux
-        goarch: amd64
-        env:
-          - CGO_ENABLED=1
-          - "CC=zig cc -target x86_64-linux-musl"
-          - "CXX=zig c++ -target x86_64-linux-musl"
-      - goos: linux
-        goarch: arm64
-        env:
-          - CGO_ENABLED=1
-          - "CC=zig cc -target aarch64-linux-musl"
-          - "CXX=zig c++ -target aarch64-linux-musl"
-    ldflags:
-      - -s -w
-      - -X github.com/open-cli-collective/newrelic-cli/internal/version.Version={{.Version}}
-      - -X github.com/open-cli-collective/newrelic-cli/internal/version.Commit={{.Commit}}
-      - -X github.com/open-cli-collective/newrelic-cli/internal/version.BuildDate={{.Date}}
-  - id: nrq-windows
+  - id: nrq-unix-win
     main: ./cmd/nrq
     binary: nrq
     env:
       - CGO_ENABLED=0
     goos:
+      - linux
       - windows
     goarch:
       - amd64
@@ -104,11 +68,11 @@ archives:
 # Linux packages (.deb and .rpm)
 nfpms:
   - id: nrq
-    # deb/rpm are linux-only: pull the static linux build (now CGO+zig+musl),
-    # never darwin/windows. `ids` (the v2 build-id filter) — `builds` is
-    # deprecated and fails `goreleaser check`.
+    # deb/rpm are linux-only: pull the static CGO-off linux build, never
+    # darwin/windows. `ids` (the v2 build-id filter) — `builds` is deprecated
+    # and fails `goreleaser check`.
     ids:
-      - nrq-linux
+      - nrq-unix-win
     package_name: nrq
     vendor: Open CLI Collective
     homepage: https://github.com/open-cli-collective/newrelic-cli

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/fatih/color v1.18.0
-	github.com/open-cli-collective/cli-common v0.2.1
+	github.com/open-cli-collective/cli-common v0.2.2
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/term v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.2.1 h1:awnwmDD9ubGUmYLg+SGkPGzbiraJsJb/eMWWTV4fwPI=
-github.com/open-cli-collective/cli-common v0.2.1/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
+github.com/open-cli-collective/cli-common v0.2.2 h1:m5Uzvw5ya/Xljgn54wuCiVP4zXE9BZKikpQBqrXLCKg=
+github.com/open-cli-collective/cli-common v0.2.2/go.mod h1:nXAwJcuAo5+bMUD2soABKDwy2o27snBggS6/OTKQgvQ=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Summary
- bump cli-common to v0.2.2
- collapse Linux and Windows back to the standard CGO-off static GoReleaser build
- remove the temporary zig Linux-CGO release workaround
- add static release build/dependency guards for Linux and Windows targets

## Verification
- go test ./...
- CGO_ENABLED=0 builds for linux/amd64, linux/arm64, windows/amd64, windows/arm64
- Linux static dependency graph checks exclude byteness/keyring and onepassword-sdk-go
- git diff --check
- goreleaser check
- goreleaser build --snapshot --clean

Closes #117

Note: snap release failure remains scoped to #118.