### PR TITLE
Remove redundant Go comments

### DIFF
--- a/api/alerts.go
+++ b/api/alerts.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 )
 
-// ListAlertPolicies returns all alert policies
 func (c *Client) ListAlertPolicies() ([]AlertPolicy, error) {
 	data, err := c.doRequest("GET", c.BaseURL+"/alerts_policies.json", nil)
 	if err != nil {
@@ -20,7 +19,6 @@ func (c *Client) ListAlertPolicies() ([]AlertPolicy, error) {
 	return resp.Policies, nil
 }
 
-// GetAlertPolicy returns a specific alert policy by ID
 func (c *Client) GetAlertPolicy(policyID string) (*AlertPolicy, error) {
 	if err := c.RequireAccountID(); err != nil {
 		return nil, err
@@ -52,7 +50,6 @@ func (c *Client) GetAlertPolicy(policyID string) (*AlertPolicy, error) {
 		return nil, err
 	}
 
-	// Navigate the nested response safely
 	actor, ok := safeMap(result["actor"])
 	if !ok {
 		return nil, &ResponseError{Message: "unexpected response format: missing actor"}

--- a/api/alerts_test.go
+++ b/api/alerts_test.go
@@ -20,12 +20,10 @@ func TestListAlertPolicies(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, policies, 3)
 
-	// Verify first policy
 	assert.Equal(t, 111, policies[0].ID)
 	assert.Equal(t, "Production Alerts", policies[0].Name)
 	assert.Equal(t, "PER_POLICY", policies[0].IncidentPreference)
 
-	// Verify request path
 	server.AssertLastPath(t, "/alerts_policies.json")
 }
 
@@ -59,7 +57,6 @@ func TestGetAlertPolicy(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// GraphQL response for GetAlertPolicy
 	response := `{
 		"data": {
 			"actor": {
@@ -87,7 +84,6 @@ func TestGetAlertPolicy(t *testing.T) {
 	assert.Equal(t, "Production Alerts", policy.Name)
 	assert.Equal(t, "PER_POLICY", policy.IncidentPreference)
 
-	// Verify GraphQL endpoint was used
 	server.AssertLastPath(t, "/graphql")
 	server.AssertLastMethod(t, "POST")
 }
@@ -96,7 +92,6 @@ func TestGetAlertPolicy_NotFound(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Policy is null when not found
 	response := `{
 		"data": {
 			"actor": {

--- a/api/applications_test.go
+++ b/api/applications_test.go
@@ -20,18 +20,15 @@ func TestListApplications(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, apps, 3)
 
-	// Verify first application
 	assert.Equal(t, 12345678, apps[0].ID)
 	assert.Equal(t, "My Application", apps[0].Name)
 	assert.Equal(t, "java", apps[0].Language)
 	assert.Equal(t, "green", apps[0].HealthStatus)
 	assert.True(t, apps[0].Reporting)
 
-	// Verify inactive application
 	assert.Equal(t, "Inactive App", apps[2].Name)
 	assert.False(t, apps[2].Reporting)
 
-	// Verify request
 	server.AssertLastPath(t, "/applications.json")
 	server.AssertLastMethod(t, "GET")
 }
@@ -79,7 +76,6 @@ func TestGetApplication(t *testing.T) {
 	assert.Equal(t, "java", app.Language)
 	assert.Equal(t, "green", app.HealthStatus)
 
-	// Verify correct path with ID
 	server.AssertLastPath(t, "/applications/12345678.json")
 }
 
@@ -108,12 +104,10 @@ func TestListApplicationMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, metrics, 4)
 
-	// Verify first metric
 	assert.Equal(t, "HttpDispatcher", metrics[0].Name)
 	assert.Contains(t, metrics[0].Values, "call_count")
 	assert.Contains(t, metrics[0].Values, "average_response_time")
 
-	// Verify path
 	server.AssertLastPath(t, "/applications/12345678/metrics.json")
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -86,7 +86,6 @@ func NewWithConfig(cfg ClientConfig) *Client {
 		Stderr:  cfg.Stderr,
 	}
 
-	// Set URLs based on region
 	if cfg.Region == "EU" {
 		c.BaseURL = "https://api.eu.newrelic.com/v2"
 		c.NerdGraphURL = "https://api.eu.newrelic.com/graphql"

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -174,7 +174,6 @@ func TestDoRequest_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "success", result["message"])
 
-	// Verify request was recorded
 	server.AssertRequestCount(t, 1)
 	server.AssertLastPath(t, "/test")
 	server.AssertLastMethod(t, "GET")
@@ -194,7 +193,6 @@ func TestDoRequest_WithBody(t *testing.T) {
 	require.NoError(t, err)
 	server.AssertLastMethod(t, "POST")
 
-	// Verify body was sent
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), `"name":"test"`)
@@ -273,7 +271,6 @@ func TestNerdGraphQuery_Success(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "Test User", actor["name"])
 
-	// Verify GraphQL endpoint was used
 	server.AssertLastPath(t, "/graphql")
 	server.AssertLastMethod(t, "POST")
 }
@@ -290,7 +287,6 @@ func TestNerdGraphQuery_WithVariables(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Verify variables were sent
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), `"variables"`)

--- a/api/connection.go
+++ b/api/connection.go
@@ -2,7 +2,6 @@ package api
 
 import "fmt"
 
-// ConnectionTestResult holds the result of a connection test
 type ConnectionTestResult struct {
 	APIKeyValid   bool
 	AccountAccess bool
@@ -16,14 +15,12 @@ type ConnectionTestResult struct {
 	ErrorMessage  string
 }
 
-// TestConnection verifies the API key and optionally account access
 func (c *Client) TestConnection() (*ConnectionTestResult, error) {
 	result := &ConnectionTestResult{
 		Region:       c.Region,
 		NerdGraphURL: c.NerdGraphURL,
 	}
 
-	// First, test API key with a simple actor query
 	query := `query { actor { user { id email } } }`
 
 	data, err := c.NerdGraphQuery(query, nil)
@@ -33,10 +30,8 @@ func (c *Client) TestConnection() (*ConnectionTestResult, error) {
 		return result, nil
 	}
 
-	// API key is valid if we got a response
 	result.APIKeyValid = true
 
-	// Extract user info
 	if actor, ok := safeMap(data["actor"]); ok {
 		if user, ok := safeMap(actor["user"]); ok {
 			result.UserID = safeString(user["id"])
@@ -44,7 +39,6 @@ func (c *Client) TestConnection() (*ConnectionTestResult, error) {
 		}
 	}
 
-	// If account ID is configured, test account access
 	if !c.AccountID.IsEmpty() {
 		accountQuery := `
 		query($accountId: Int!) {
@@ -65,7 +59,6 @@ func (c *Client) TestConnection() (*ConnectionTestResult, error) {
 			return result, nil
 		}
 
-		// Extract account info
 		if actor, ok := safeMap(accountData["actor"]); ok {
 			if account, ok := safeMap(actor["account"]); ok {
 				result.AccountAccess = true

--- a/api/dashboards.go
+++ b/api/dashboards.go
@@ -2,7 +2,6 @@ package api
 
 import "fmt"
 
-// ListDashboards returns all dashboards for the account
 func (c *Client) ListDashboards() ([]Dashboard, error) {
 	if err := c.RequireAccountID(); err != nil {
 		return nil, err
@@ -35,7 +34,6 @@ func (c *Client) ListDashboards() ([]Dashboard, error) {
 		return nil, err
 	}
 
-	// Navigate the nested response safely
 	actor, ok := safeMap(result["actor"])
 	if !ok {
 		return nil, &ResponseError{Message: "unexpected response format: missing actor"}
@@ -69,7 +67,6 @@ func (c *Client) ListDashboards() ([]Dashboard, error) {
 	return dashboards, nil
 }
 
-// GetDashboard returns detailed information for a specific dashboard
 func (c *Client) GetDashboard(guid EntityGUID) (*DashboardDetail, error) {
 	query := `
 	query($guid: EntityGuid!) {
@@ -121,7 +118,6 @@ func (c *Client) GetDashboard(guid EntityGUID) (*DashboardDetail, error) {
 		Permissions: safeString(entity["permissions"]),
 	}
 
-	// Parse pages
 	if pages, ok := safeSlice(entity["pages"]); ok {
 		for _, p := range pages {
 			page, ok := safeMap(p)
@@ -162,7 +158,6 @@ func (c *Client) GetDashboard(guid EntityGUID) (*DashboardDetail, error) {
 	return dashboard, nil
 }
 
-// DashboardInput represents the input for creating or updating a dashboard
 type DashboardInput struct {
 	Name        string               `json:"name"`
 	Description string               `json:"description,omitempty"`
@@ -170,13 +165,11 @@ type DashboardInput struct {
 	Pages       []DashboardPageInput `json:"pages"`
 }
 
-// DashboardPageInput represents a page in dashboard input
 type DashboardPageInput struct {
 	Name    string                 `json:"name"`
 	Widgets []DashboardWidgetInput `json:"widgets,omitempty"`
 }
 
-// DashboardWidgetInput represents a widget in dashboard page input
 type DashboardWidgetInput struct {
 	Title         string                 `json:"title"`
 	Visualization map[string]interface{} `json:"visualization"`
@@ -184,7 +177,6 @@ type DashboardWidgetInput struct {
 	Configuration map[string]interface{} `json:"rawConfiguration"`
 }
 
-// CreateDashboard creates a new dashboard from the provided input
 func (c *Client) CreateDashboard(input *DashboardInput) (*DashboardDetail, error) {
 	if err := c.RequireAccountID(); err != nil {
 		return nil, err
@@ -216,7 +208,6 @@ func (c *Client) CreateDashboard(input *DashboardInput) (*DashboardDetail, error
 		}
 	}`
 
-	// Convert input to the format expected by NerdGraph
 	dashboardMap := map[string]interface{}{
 		"name":        input.Name,
 		"permissions": input.Permissions,
@@ -265,7 +256,6 @@ func (c *Client) CreateDashboard(input *DashboardInput) (*DashboardDetail, error
 		return nil, &ResponseError{Message: "unexpected response format: missing dashboardCreate"}
 	}
 
-	// Check for errors
 	if errors, ok := safeSlice(dashboardCreate["errors"]); ok && len(errors) > 0 {
 		if errMap, ok := safeMap(errors[0]); ok {
 			return nil, fmt.Errorf("failed to create dashboard: %s", safeString(errMap["description"]))
@@ -280,7 +270,6 @@ func (c *Client) CreateDashboard(input *DashboardInput) (*DashboardDetail, error
 	return parseDashboardEntity(entityResult), nil
 }
 
-// UpdateDashboard updates an existing dashboard
 func (c *Client) UpdateDashboard(guid EntityGUID, input *DashboardInput) (*DashboardDetail, error) {
 	mutation := `
 	mutation($guid: EntityGuid!, $dashboard: DashboardInput!) {
@@ -308,7 +297,6 @@ func (c *Client) UpdateDashboard(guid EntityGUID, input *DashboardInput) (*Dashb
 		}
 	}`
 
-	// Convert input to the format expected by NerdGraph
 	dashboardMap := map[string]interface{}{
 		"name": input.Name,
 	}
@@ -356,7 +344,6 @@ func (c *Client) UpdateDashboard(guid EntityGUID, input *DashboardInput) (*Dashb
 		return nil, &ResponseError{Message: "unexpected response format: missing dashboardUpdate"}
 	}
 
-	// Check for errors
 	if errors, ok := safeSlice(dashboardUpdate["errors"]); ok && len(errors) > 0 {
 		if errMap, ok := safeMap(errors[0]); ok {
 			return nil, fmt.Errorf("failed to update dashboard: %s", safeString(errMap["description"]))
@@ -371,7 +358,6 @@ func (c *Client) UpdateDashboard(guid EntityGUID, input *DashboardInput) (*Dashb
 	return parseDashboardEntity(entityResult), nil
 }
 
-// parseDashboardEntity converts a NerdGraph entity result to DashboardDetail
 func parseDashboardEntity(entity map[string]interface{}) *DashboardDetail {
 	dashboard := &DashboardDetail{
 		GUID:        EntityGUID(safeString(entity["guid"])),
@@ -420,7 +406,6 @@ func parseDashboardEntity(entity map[string]interface{}) *DashboardDetail {
 	return dashboard
 }
 
-// DeleteDashboard deletes a dashboard by GUID
 func (c *Client) DeleteDashboard(guid EntityGUID) error {
 	mutation := `
 	mutation($guid: EntityGuid!) {
@@ -442,7 +427,6 @@ func (c *Client) DeleteDashboard(guid EntityGUID) error {
 		return err
 	}
 
-	// Check for deletion errors
 	dashboardDelete, ok := safeMap(result["dashboardDelete"])
 	if !ok {
 		return &ResponseError{Message: "unexpected response format: missing dashboardDelete"}
@@ -450,7 +434,6 @@ func (c *Client) DeleteDashboard(guid EntityGUID) error {
 
 	status := safeString(dashboardDelete["status"])
 	if status != "SUCCESS" {
-		// Check for specific errors
 		if errors, ok := safeSlice(dashboardDelete["errors"]); ok && len(errors) > 0 {
 			if errMap, ok := safeMap(errors[0]); ok {
 				return fmt.Errorf("failed to delete dashboard: %s", safeString(errMap["description"]))

--- a/api/dashboards_test.go
+++ b/api/dashboards_test.go
@@ -20,15 +20,12 @@ func TestListDashboards(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dashboards, 2)
 
-	// Verify first dashboard
 	assert.Equal(t, EntityGUID("MXxWSVp8REFTSEJPQVJEfDEyMzQ1"), dashboards[0].GUID)
 	assert.Equal(t, "Production Overview", dashboards[0].Name)
 	assert.Equal(t, 12345, dashboards[0].AccountID)
 
-	// Verify second dashboard
 	assert.Equal(t, "API Performance", dashboards[1].Name)
 
-	// Verify GraphQL endpoint and query
 	server.AssertLastPath(t, "/graphql")
 	req := server.LastRequest()
 	require.NotNil(t, req)
@@ -103,12 +100,10 @@ func TestGetDashboard(t *testing.T) {
 	assert.Equal(t, "Main production metrics dashboard", dashboard.Description)
 	assert.Equal(t, "PUBLIC_READ_WRITE", dashboard.Permissions)
 
-	// Verify pages
 	require.Len(t, dashboard.Pages, 2)
 	assert.Equal(t, "Overview", dashboard.Pages[0].Name)
 	assert.Equal(t, "Details", dashboard.Pages[1].Name)
 
-	// Verify widgets on first page
 	require.Len(t, dashboard.Pages[0].Widgets, 2)
 	assert.Equal(t, "Error Rate", dashboard.Pages[0].Widgets[0].Title)
 	assert.Equal(t, "Throughput", dashboard.Pages[0].Widgets[1].Title)
@@ -125,7 +120,6 @@ func TestGetDashboard_WithWidgets(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Check widget visualization
 	widget := dashboard.Pages[0].Widgets[0]
 	assert.Equal(t, "widget-1", widget.ID)
 	require.NotNil(t, widget.Visualization)

--- a/api/deployments_test.go
+++ b/api/deployments_test.go
@@ -20,13 +20,11 @@ func TestListDeployments(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, deployments, 2)
 
-	// Verify first deployment
 	assert.Equal(t, 9001, deployments[0].ID)
 	assert.Equal(t, "v1.2.3", deployments[0].Revision)
 	assert.Equal(t, "Feature release: new dashboard", deployments[0].Description)
 	assert.Equal(t, "deploy-bot", deployments[0].User)
 
-	// Verify request path
 	server.AssertLastPath(t, "/applications/12345678/deployments.json")
 }
 
@@ -71,11 +69,9 @@ func TestCreateDeployment(t *testing.T) {
 	assert.Equal(t, 9002, deployment.ID)
 	assert.Equal(t, "v1.2.4", deployment.Revision)
 
-	// Verify request
 	server.AssertLastPath(t, "/applications/12345678/deployments.json")
 	server.AssertLastMethod(t, "POST")
 
-	// Verify body contains deployment data
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), `"revision":"v1.2.4"`)
@@ -95,7 +91,6 @@ func TestCreateDeployment_MinimalFields(t *testing.T) {
 	require.NotNil(t, deployment)
 	assert.Equal(t, "v1.0.0", deployment.Revision)
 
-	// Verify only revision is in body (no empty fields)
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), `"revision":"v1.0.0"`)

--- a/api/entities_test.go
+++ b/api/entities_test.go
@@ -20,7 +20,6 @@ func TestSearchEntities(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entities, 2)
 
-	// Verify first entity (APM application)
 	assert.Equal(t, EntityGUID("MXxBUE18QVBQTElDQVRJT058MTIzNDU2Nzg="), entities[0].GUID)
 	assert.Equal(t, "My Application", entities[0].Name)
 	assert.Equal(t, "APPLICATION", entities[0].Type)
@@ -28,12 +27,10 @@ func TestSearchEntities(t *testing.T) {
 	assert.Equal(t, "APM", entities[0].Domain)
 	assert.Equal(t, 12345, entities[0].AccountID)
 
-	// Verify second entity (Infrastructure host)
 	assert.Equal(t, "web-server-01", entities[1].Name)
 	assert.Equal(t, "HOST", entities[1].Type)
 	assert.Equal(t, "INFRA", entities[1].Domain)
 
-	// Verify GraphQL endpoint and query variable
 	server.AssertLastPath(t, "/graphql")
 	req := server.LastRequest()
 	require.NotNil(t, req)
@@ -75,7 +72,6 @@ func TestSearchEntities_ByType(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Verify query was sent correctly
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), "APPLICATION")

--- a/api/keys.go
+++ b/api/keys.go
@@ -1,11 +1,7 @@
-// Package api - keys.go provides methods for managing New Relic API keys
-// via the NerdGraph apiAccess API (keySearch, apiAccessCreateKeys,
-// apiAccessUpdateKeys, apiAccessDeleteKeys).
 package api
 
 import "fmt"
 
-// apiAccessKeyFields is the common set of GraphQL fields for API access keys
 const apiAccessKeyFields = `
 	id
 	name
@@ -17,9 +13,7 @@ const apiAccessKeyFields = `
 	}
 `
 
-// SearchAPIKeys searches for API keys with optional type and account filters
 func (c *Client) SearchAPIKeys(keyTypes []string, accountID int) ([]ApiAccessKey, error) {
-	// Build the types array
 	typesStr := "USER, INGEST"
 	if len(keyTypes) > 0 {
 		typesStr = ""
@@ -31,7 +25,6 @@ func (c *Client) SearchAPIKeys(keyTypes []string, accountID int) ([]ApiAccessKey
 		}
 	}
 
-	// Build scope clause
 	scopeClause := ""
 	if accountID > 0 {
 		scopeClause = fmt.Sprintf(", scope: {accountIds: %d}", accountID)
@@ -80,7 +73,6 @@ func (c *Client) SearchAPIKeys(keyTypes []string, accountID int) ([]ApiAccessKey
 	return keys, nil
 }
 
-// GetAPIAccessKey retrieves a specific API key by ID and type
 func (c *Client) GetAPIAccessKey(keyID string, keyType string) (*ApiAccessKey, error) {
 	query := fmt.Sprintf(`
 	{
@@ -115,7 +107,6 @@ func (c *Client) GetAPIAccessKey(keyID string, keyType string) (*ApiAccessKey, e
 	return &key, nil
 }
 
-// FindAPIAccessKey retrieves a key by ID, trying USER then INGEST type
 func (c *Client) FindAPIAccessKey(keyID string) (*ApiAccessKey, error) {
 	key, err := c.GetAPIAccessKey(keyID, "USER")
 	if err == nil {
@@ -124,7 +115,6 @@ func (c *Client) FindAPIAccessKey(keyID string) (*ApiAccessKey, error) {
 	return c.GetAPIAccessKey(keyID, "INGEST")
 }
 
-// GetCurrentUserID returns the current user's ID from NerdGraph
 func (c *Client) GetCurrentUserID() (int, error) {
 	query := `{ actor { user { id } } }`
 
@@ -145,7 +135,6 @@ func (c *Client) GetCurrentUserID() (int, error) {
 	return safeInt(user["id"]), nil
 }
 
-// CreateUserAPIKey creates a new user API key
 func (c *Client) CreateUserAPIKey(accountID, userID int, name, notes string) (*ApiAccessKey, error) {
 	mutation := fmt.Sprintf(`
 	mutation {
@@ -163,7 +152,6 @@ func (c *Client) CreateUserAPIKey(accountID, userID int, name, notes string) (*A
 	return c.execCreateKeys(mutation)
 }
 
-// CreateIngestAPIKey creates a new ingest API key (LICENSE or BROWSER)
 func (c *Client) CreateIngestAPIKey(accountID int, ingestType, name, notes string) (*ApiAccessKey, error) {
 	mutation := fmt.Sprintf(`
 	mutation {
@@ -205,9 +193,7 @@ func (c *Client) execCreateKeys(mutation string) (*ApiAccessKey, error) {
 	return &key, nil
 }
 
-// UpdateAPIAccessKey updates an existing API key's name and/or notes
 func (c *Client) UpdateAPIAccessKey(keyID string, keyType string, update ApiAccessKeyUpdate) (*ApiAccessKey, error) {
-	// Build the update fields
 	fields := fmt.Sprintf(`keyId: "%s"`, keyID)
 	if update.Name != nil {
 		fields += fmt.Sprintf(`, name: "%s"`, escapeGraphQL(*update.Name))
@@ -216,7 +202,6 @@ func (c *Client) UpdateAPIAccessKey(keyID string, keyType string, update ApiAcce
 		fields += fmt.Sprintf(`, notes: "%s"`, escapeGraphQL(*update.Notes))
 	}
 
-	// Use the appropriate key type bucket
 	var keyBucket string
 	switch keyType {
 	case "USER":
@@ -262,9 +247,7 @@ func (c *Client) UpdateAPIAccessKey(keyID string, keyType string, update ApiAcce
 	return &key, nil
 }
 
-// DeleteAPIAccessKeys deletes API keys by their IDs, separated by type
 func (c *Client) DeleteAPIAccessKeys(userKeyIDs, ingestKeyIDs []string) ([]string, error) {
-	// Build the keys argument
 	parts := []string{}
 	if len(userKeyIDs) > 0 {
 		ids := formatStringSlice(userKeyIDs)
@@ -329,7 +312,6 @@ func (c *Client) DeleteAPIAccessKeys(userKeyIDs, ingestKeyIDs []string) ([]strin
 	return deletedIDs, nil
 }
 
-// parseApiAccessKey converts a NerdGraph response map to an ApiAccessKey
 func parseApiAccessKey(v interface{}) ApiAccessKey {
 	m, ok := safeMap(v)
 	if !ok {
@@ -345,7 +327,6 @@ func parseApiAccessKey(v interface{}) ApiAccessKey {
 	}
 }
 
-// escapeGraphQL escapes special characters for GraphQL string values
 func escapeGraphQL(s string) string {
 	result := ""
 	for _, c := range s {
@@ -367,7 +348,6 @@ func escapeGraphQL(s string) string {
 	return result
 }
 
-// formatStringSlice formats a string slice as GraphQL string array items
 func formatStringSlice(ss []string) string {
 	result := ""
 	for i, s := range ss {

--- a/api/keys_test.go
+++ b/api/keys_test.go
@@ -46,7 +46,6 @@ func TestSearchAPIKeys_FilterByType(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Verify the query contained USER type
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), "USER")
@@ -109,7 +108,6 @@ func TestGetAPIAccessKey(t *testing.T) {
 	assert.Equal(t, "USER", key.Type)
 	assert.Equal(t, "For automation", key.Notes)
 
-	// Verify request contained key ID and type
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), "NRAK-ABCDEF1234567890")
@@ -151,7 +149,6 @@ func TestFindAPIAccessKey_FoundAsUser(t *testing.T) {
 	require.NotNil(t, key)
 	assert.Equal(t, "USER", key.Type)
 
-	// Should have only made one request (found on first try)
 	server.AssertRequestCount(t, 1)
 }
 
@@ -164,10 +161,8 @@ func TestFindAPIAccessKey_FoundAsIngest(t *testing.T) {
 		requestCount++
 		w.Header().Set("Content-Type", "application/json")
 		if requestCount == 1 {
-			// First request (USER) returns null key
 			w.Write([]byte(`{"data": {"actor": {"apiAccess": {"key": null}}}}`))
 		} else {
-			// Second request (INGEST) returns the key
 			w.Write([]byte(`{
 				"data": {
 					"actor": {

--- a/api/logs.go
+++ b/api/logs.go
@@ -2,7 +2,6 @@ package api
 
 import "fmt"
 
-// ListLogParsingRules returns all log parsing rules for the account
 func (c *Client) ListLogParsingRules() ([]LogParsingRule, error) {
 	if err := c.RequireAccountID(); err != nil {
 		return nil, err
@@ -61,7 +60,6 @@ func (c *Client) ListLogParsingRules() ([]LogParsingRule, error) {
 		if !ok {
 			continue
 		}
-		// Skip deleted rules
 		if deleted, ok := rule["deleted"].(bool); ok && deleted {
 			continue
 		}
@@ -79,7 +77,6 @@ func (c *Client) ListLogParsingRules() ([]LogParsingRule, error) {
 	return rules, nil
 }
 
-// CreateLogParsingRule creates a new log parsing rule
 func (c *Client) CreateLogParsingRule(description, grok, nrql string, enabled bool, lucene string) (*LogParsingRule, error) {
 	if err := c.RequireAccountID(); err != nil {
 		return nil, err
@@ -143,7 +140,6 @@ func (c *Client) CreateLogParsingRule(description, grok, nrql string, enabled bo
 	}, nil
 }
 
-// GetLogParsingRule returns a specific log parsing rule by ID
 func (c *Client) GetLogParsingRule(ruleID string) (*LogParsingRule, error) {
 	rules, err := c.ListLogParsingRules()
 	if err != nil {
@@ -159,8 +155,6 @@ func (c *Client) GetLogParsingRule(ruleID string) (*LogParsingRule, error) {
 	return nil, fmt.Errorf("rule not found: %s", ruleID)
 }
 
-// LogParsingRuleUpdate contains the fields that can be updated on a log parsing rule.
-// All fields are optional - only non-nil values will be included in the update.
 type LogParsingRuleUpdate struct {
 	Description *string
 	Enabled     *bool
@@ -169,7 +163,6 @@ type LogParsingRuleUpdate struct {
 	NRQL        *string
 }
 
-// UpdateLogParsingRule updates an existing log parsing rule.
 // The NerdGraph API requires all fields to be provided, so this function
 // fetches the existing rule first and merges the updates.
 func (c *Client) UpdateLogParsingRule(ruleID string, update LogParsingRuleUpdate) (*LogParsingRule, error) {
@@ -177,13 +170,11 @@ func (c *Client) UpdateLogParsingRule(ruleID string, update LogParsingRuleUpdate
 		return nil, err
 	}
 
-	// Fetch existing rule to get current values
 	existing, err := c.GetLogParsingRule(ruleID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Merge updates with existing values
 	description := existing.Description
 	if update.Description != nil {
 		description = *update.Description
@@ -264,7 +255,6 @@ func (c *Client) UpdateLogParsingRule(ruleID string, update LogParsingRuleUpdate
 	}, nil
 }
 
-// DeleteLogParsingRule deletes a log parsing rule
 func (c *Client) DeleteLogParsingRule(ruleID string) error {
 	if err := c.RequireAccountID(); err != nil {
 		return err

--- a/api/logs_test.go
+++ b/api/logs_test.go
@@ -18,20 +18,16 @@ func TestListLogParsingRules(t *testing.T) {
 	rules, err := client.ListLogParsingRules()
 
 	require.NoError(t, err)
-	// Should only have 2 rules (deleted one is filtered out)
 	require.Len(t, rules, 2)
 
-	// Verify first rule
 	assert.Equal(t, "rule-001", rules[0].ID)
 	assert.Equal(t, "Parse Apache access logs", rules[0].Description)
 	assert.True(t, rules[0].Enabled)
 	assert.Equal(t, "%{COMBINEDAPACHELOG}", rules[0].Grok)
 
-	// Verify second rule
 	assert.Equal(t, "rule-002", rules[1].ID)
 	assert.Equal(t, "Parse JSON application logs", rules[1].Description)
 
-	// Verify GraphQL endpoint was used
 	server.AssertLastPath(t, "/graphql")
 }
 
@@ -39,7 +35,6 @@ func TestListLogParsingRules_FiltersDeleted(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Response with only a deleted rule
 	response := `{
 		"data": {
 			"actor": {
@@ -101,7 +96,6 @@ func TestCreateLogParsingRule(t *testing.T) {
 	assert.Equal(t, "Newly created rule", rule.Description)
 	assert.True(t, rule.Enabled)
 
-	// Verify request
 	server.AssertLastPath(t, "/graphql")
 	server.AssertLastMethod(t, "POST")
 }
@@ -164,7 +158,6 @@ func TestDeleteLogParsingRule(t *testing.T) {
 	server.AssertLastPath(t, "/graphql")
 	server.AssertLastMethod(t, "POST")
 
-	// Verify rule ID was in the mutation
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), "rule-001")
@@ -209,16 +202,13 @@ func TestUpdateLogParsingRule(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Set up handler to return different responses for list and update requests
 	requestCount := 0
 	server.SetHandler(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 		w.Header().Set("Content-Type", "application/json")
 		if requestCount == 1 {
-			// First request is to list rules (to get existing values)
 			w.Write(LoadTestFixture(t, "log_parsing_rules.json"))
 		} else {
-			// Second request is the actual update
 			w.Write(LoadTestFixture(t, "log_rule_updated.json"))
 		}
 	})
@@ -238,7 +228,6 @@ func TestUpdateLogParsingRule(t *testing.T) {
 	assert.Equal(t, "Updated description", rule.Description)
 	assert.False(t, rule.Enabled)
 
-	// Verify two requests were made (list + update)
 	assert.Equal(t, 2, requestCount)
 }
 
@@ -246,22 +235,18 @@ func TestUpdateLogParsingRule_PartialUpdate(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Set up handler to return different responses for list and update requests
 	requestCount := 0
 	server.SetHandler(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 		w.Header().Set("Content-Type", "application/json")
 		if requestCount == 1 {
-			// First request is to list rules
 			w.Write(LoadTestFixture(t, "log_parsing_rules.json"))
 		} else {
-			// Second request is the actual update
 			w.Write(LoadTestFixture(t, "log_rule_updated.json"))
 		}
 	})
 
 	client := NewTestClient(server)
-	// Only update grok pattern
 	grok := "%{IP:client_ip} %{WORD:method}"
 	_, err := client.UpdateLogParsingRule("rule-001", LogParsingRuleUpdate{
 		Grok: &grok,
@@ -269,7 +254,6 @@ func TestUpdateLogParsingRule_PartialUpdate(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Verify the update request contains grok
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), "grok")
@@ -279,7 +263,6 @@ func TestUpdateLogParsingRule_RuleNotFound(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Return rules list that doesn't include the requested rule
 	server.SetResponse(http.StatusOK, LoadTestFixture(t, "log_parsing_rules.json"))
 
 	client := NewTestClient(server)
@@ -296,16 +279,13 @@ func TestUpdateLogParsingRule_UpdateError(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Set up handler to return rules list first, then an error on update
 	requestCount := 0
 	server.SetHandler(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
 		w.Header().Set("Content-Type", "application/json")
 		if requestCount == 1 {
-			// First request is to list rules
 			w.Write(LoadTestFixture(t, "log_parsing_rules.json"))
 		} else {
-			// Second request returns an error
 			w.Write([]byte(`{
 				"data": {
 					"logConfigurationsUpdateParsingRule": {

--- a/api/nrql_test.go
+++ b/api/nrql_test.go
@@ -21,15 +21,12 @@ func TestQueryNRQL(t *testing.T) {
 	require.NotNil(t, result)
 	require.Len(t, result.Results, 3)
 
-	// Verify first result
 	assert.Equal(t, float64(1500), result.Results[0]["count"])
 	assert.Equal(t, "WebTransaction/Controller/api/v1/users", result.Results[0]["facet"])
 
-	// Verify GraphQL endpoint was used
 	server.AssertLastPath(t, "/graphql")
 	server.AssertLastMethod(t, "POST")
 
-	// Verify query was sent
 	req := server.LastRequest()
 	require.NotNil(t, req)
 	assert.Contains(t, string(req.Body), "nrql")
@@ -102,7 +99,6 @@ func TestQueryNRQL_InvalidResponse(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Response missing expected structure
 	response := `{
 		"data": {
 			"actor": {}

--- a/api/resolve.go
+++ b/api/resolve.go
@@ -4,34 +4,23 @@ import (
 	"fmt"
 )
 
-// ResolveAppID resolves an application identifier to a numeric app ID.
-// It accepts:
-// - A numeric app ID (returned as-is)
-// - An entity GUID (extracts the app ID)
-// - An application name (looks up via entity search)
 func (c *Client) ResolveAppID(identifier string) (string, error) {
-	// Check if it's already a numeric ID
 	if isNumeric(identifier) {
 		return identifier, nil
 	}
 
-	// Check if it looks like a base64-encoded GUID
 	if IsValidEntityGUID(identifier) {
 		guid := EntityGUID(identifier)
 		appID, err := guid.AppID()
 		if err == nil {
 			return appID, nil
 		}
-		// If GUID parsing fails, fall through to name search
 	}
 
-	// Try to resolve as an application name
 	return c.resolveAppName(identifier)
 }
 
-// resolveAppName looks up an application by name and returns its ID
 func (c *Client) resolveAppName(name string) (string, error) {
-	// Search for APM applications with the exact name
 	query := fmt.Sprintf("name = '%s' AND domain = 'APM' AND type = 'APPLICATION'", name)
 	entities, err := c.SearchEntities(query)
 	if err != nil {
@@ -46,7 +35,6 @@ func (c *Client) resolveAppName(name string) (string, error) {
 		return "", fmt.Errorf("multiple applications found with name '%s', please use --guid or app ID", name)
 	}
 
-	// Extract app ID from the entity GUID
 	entity := entities[0]
 	appID, err := entity.GUID.AppID()
 	if err != nil {
@@ -56,7 +44,6 @@ func (c *Client) resolveAppName(name string) (string, error) {
 	return appID, nil
 }
 
-// isNumeric checks if a string contains only digits
 func isNumeric(s string) bool {
 	if s == "" {
 		return false

--- a/api/synthetics.go
+++ b/api/synthetics.go
@@ -2,7 +2,6 @@ package api
 
 import "encoding/json"
 
-// ListSyntheticMonitors returns all synthetic monitors
 func (c *Client) ListSyntheticMonitors() ([]SyntheticMonitor, error) {
 	data, err := c.doRequest("GET", c.SyntheticsURL+"/monitors.json", nil)
 	if err != nil {
@@ -17,7 +16,6 @@ func (c *Client) ListSyntheticMonitors() ([]SyntheticMonitor, error) {
 	return resp.Monitors, nil
 }
 
-// GetSyntheticMonitor returns a specific synthetic monitor by ID
 func (c *Client) GetSyntheticMonitor(monitorID string) (*SyntheticMonitor, error) {
 	data, err := c.doRequest("GET", c.SyntheticsURL+"/monitors/"+monitorID, nil)
 	if err != nil {
@@ -32,7 +30,6 @@ func (c *Client) GetSyntheticMonitor(monitorID string) (*SyntheticMonitor, error
 	return &monitor, nil
 }
 
-// SyntheticMonitorInput represents the input for creating or updating a synthetic monitor
 type SyntheticMonitorInput struct {
 	Name      string   `json:"name"`
 	Type      string   `json:"type"`
@@ -43,9 +40,7 @@ type SyntheticMonitorInput struct {
 	Script    string   `json:"script,omitempty"`
 }
 
-// CreateSyntheticMonitor creates a new synthetic monitor
 func (c *Client) CreateSyntheticMonitor(input *SyntheticMonitorInput) (*SyntheticMonitor, error) {
-	// Build the request body
 	body := map[string]interface{}{
 		"name":      input.Name,
 		"type":      input.Type,
@@ -73,9 +68,7 @@ func (c *Client) CreateSyntheticMonitor(input *SyntheticMonitorInput) (*Syntheti
 	return &monitor, nil
 }
 
-// UpdateSyntheticMonitor updates an existing synthetic monitor
 func (c *Client) UpdateSyntheticMonitor(monitorID string, input *SyntheticMonitorInput) (*SyntheticMonitor, error) {
-	// Build the request body
 	body := map[string]interface{}{
 		"name":      input.Name,
 		"frequency": input.Frequency,
@@ -102,7 +95,6 @@ func (c *Client) UpdateSyntheticMonitor(monitorID string, input *SyntheticMonito
 	return &monitor, nil
 }
 
-// DeleteSyntheticMonitor deletes a synthetic monitor by ID
 func (c *Client) DeleteSyntheticMonitor(monitorID string) error {
 	_, err := c.doRequest("DELETE", c.SyntheticsURL+"/monitors/"+monitorID, nil)
 	return err

--- a/api/synthetics_test.go
+++ b/api/synthetics_test.go
@@ -20,7 +20,6 @@ func TestListSyntheticMonitors(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, monitors, 3)
 
-	// Verify first monitor
 	assert.Equal(t, "syn-001", monitors[0].ID)
 	assert.Equal(t, "Homepage Check", monitors[0].Name)
 	assert.Equal(t, "SIMPLE", monitors[0].Type)
@@ -28,7 +27,6 @@ func TestListSyntheticMonitors(t *testing.T) {
 	assert.Equal(t, "ENABLED", monitors[0].Status)
 	assert.Equal(t, "https://example.com", monitors[0].URI)
 
-	// Verify request path uses synthetics URL
 	server.AssertLastPath(t, "/synthetics/monitors.json")
 }
 
@@ -75,7 +73,6 @@ func TestGetSyntheticMonitor(t *testing.T) {
 	assert.Equal(t, "SIMPLE", monitor.Type)
 	assert.Equal(t, "https://example.com", monitor.URI)
 
-	// Verify request path includes monitor ID
 	server.AssertLastPath(t, "/synthetics/monitors/syn-001")
 }
 

--- a/api/testhelpers_test.go
+++ b/api/testhelpers_test.go
@@ -15,7 +15,6 @@ import (
 //go:embed testdata/*.json
 var testdataFS embed.FS
 
-// RecordedRequest captures details of an HTTP request for test assertions
 type RecordedRequest struct {
 	Method  string
 	Path    string
@@ -23,7 +22,6 @@ type RecordedRequest struct {
 	Body    []byte
 }
 
-// MockServer is a test HTTP server that records requests and returns configured responses
 type MockServer struct {
 	*httptest.Server
 	mu         sync.Mutex
@@ -33,7 +31,6 @@ type MockServer struct {
 	handler    http.HandlerFunc
 }
 
-// NewMockServer creates a new mock server with default 200 OK response
 func NewMockServer() *MockServer {
 	m := &MockServer{
 		statusCode: http.StatusOK,
@@ -41,7 +38,6 @@ func NewMockServer() *MockServer {
 	}
 
 	m.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Record the request
 		body, _ := io.ReadAll(r.Body)
 		m.mu.Lock()
 		m.requests = append(m.requests, RecordedRequest{
@@ -51,7 +47,6 @@ func NewMockServer() *MockServer {
 			Body:    body,
 		})
 
-		// Use custom handler if set
 		if m.handler != nil {
 			m.mu.Unlock()
 			m.handler(w, r)
@@ -70,7 +65,6 @@ func NewMockServer() *MockServer {
 	return m
 }
 
-// SetResponse configures the response for subsequent requests
 func (m *MockServer) SetResponse(status int, body interface{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -87,21 +81,18 @@ func (m *MockServer) SetResponse(status int, body interface{}) {
 	}
 }
 
-// SetHandler sets a custom handler for complex scenarios
 func (m *MockServer) SetHandler(h http.HandlerFunc) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.handler = h
 }
 
-// Requests returns all recorded requests
 func (m *MockServer) Requests() []RecordedRequest {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]RecordedRequest{}, m.requests...)
 }
 
-// LastRequest returns the most recent request
 func (m *MockServer) LastRequest() *RecordedRequest {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -111,14 +102,12 @@ func (m *MockServer) LastRequest() *RecordedRequest {
 	return &m.requests[len(m.requests)-1]
 }
 
-// Reset clears recorded requests
 func (m *MockServer) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.requests = nil
 }
 
-// AssertRequestCount checks the number of requests made
 func (m *MockServer) AssertRequestCount(t *testing.T, expected int) {
 	t.Helper()
 	actual := len(m.Requests())
@@ -127,7 +116,6 @@ func (m *MockServer) AssertRequestCount(t *testing.T, expected int) {
 	}
 }
 
-// AssertLastPath checks the path of the last request
 func (m *MockServer) AssertLastPath(t *testing.T, expected string) {
 	t.Helper()
 	req := m.LastRequest()
@@ -137,7 +125,6 @@ func (m *MockServer) AssertLastPath(t *testing.T, expected string) {
 	}
 }
 
-// AssertLastMethod checks the HTTP method of the last request
 func (m *MockServer) AssertLastMethod(t *testing.T, expected string) {
 	t.Helper()
 	req := m.LastRequest()
@@ -147,7 +134,6 @@ func (m *MockServer) AssertLastMethod(t *testing.T, expected string) {
 	}
 }
 
-// AssertLastHeader checks a header value in the last request
 func (m *MockServer) AssertLastHeader(t *testing.T, key, expected string) {
 	t.Helper()
 	req := m.LastRequest()
@@ -158,7 +144,6 @@ func (m *MockServer) AssertLastHeader(t *testing.T, key, expected string) {
 	}
 }
 
-// NewTestClient creates an API client configured to use the mock server
 func NewTestClient(server *MockServer) *Client {
 	return &Client{
 		APIKey:        "test-api-key",
@@ -171,7 +156,6 @@ func NewTestClient(server *MockServer) *Client {
 	}
 }
 
-// LoadTestFixture loads a JSON fixture file from testdata directory
 func LoadTestFixture(t *testing.T, filename string) []byte {
 	t.Helper()
 	data, err := testdataFS.ReadFile("testdata/" + filename)

--- a/api/users.go
+++ b/api/users.go
@@ -33,7 +33,6 @@ func (c *Client) ListUsers() ([]User, error) {
 		return nil, err
 	}
 
-	// Navigate the nested structure safely
 	actor, ok := safeMap(result["actor"])
 	if !ok {
 		return nil, &ResponseError{Message: "unexpected response format: missing actor"}
@@ -124,7 +123,6 @@ func (c *Client) GetUser(userID string) (*User, error) {
 		return nil, err
 	}
 
-	// Navigate and find the user
 	actor, ok := safeMap(result["actor"])
 	if !ok {
 		return nil, &ResponseError{Message: "unexpected response format"}

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -20,17 +20,14 @@ func TestListUsers(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, users, 2)
 
-	// Verify first user
 	assert.Equal(t, "user-001", users[0].ID)
 	assert.Equal(t, "Alice Admin", users[0].Name)
 	assert.Equal(t, "alice@example.com", users[0].Email)
 	assert.Equal(t, "Default", users[0].AuthenticationDomain)
 
-	// Verify second user
 	assert.Equal(t, "user-002", users[1].ID)
 	assert.Equal(t, "Bob Developer", users[1].Name)
 
-	// Verify GraphQL endpoint was used
 	server.AssertLastPath(t, "/graphql")
 }
 
@@ -64,7 +61,6 @@ func TestListUsers_MultiDomain(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Response with multiple authentication domains
 	response := `{
 		"data": {
 			"actor": {
@@ -105,7 +101,6 @@ func TestListUsers_MultiDomain(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, users, 2)
 
-	// Users from different domains
 	assert.Equal(t, "Default", users[0].AuthenticationDomain)
 	assert.Equal(t, "SSO", users[1].AuthenticationDomain)
 }
@@ -148,7 +143,6 @@ func TestGetUser_NotFound(t *testing.T) {
 	server := NewMockServer()
 	defer server.Close()
 
-	// Response with no matching user
 	response := `{
 		"data": {
 			"actor": {


### PR DESCRIPTION
This trims low-value comments in Go files where the comment only restated the adjacent code, while leaving rationale comments intact.\n\nCloses #121